### PR TITLE
Reject corrupt recovery state and exercise real receipt loss

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @RaycarlLei

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,28 @@
+name: Reproducible bug
+description: Report unexpected journal behavior with a synthetic reproduction.
+body:
+  - type: markdown
+    attributes:
+      value: For security concerns, use private vulnerability reporting. Do not attach real databases, receipts, credentials or customer traces.
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Expected and observed behavior
+      description: Include the recovery policy and the sequence of calls or failures.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal synthetic reproduction
+      description: Provide runnable code, or a failing test with its seed and path.
+      render: typescript
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Package version or commit, Node version, OS, storage adapter and filesystem type.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Describe the observable problem and the behavior after this change.
+
+Explain any change to identity, recovery, storage or compatibility guarantees.
+Link the regression test or reproducible experiment and record the commands run.
+For a storage adapter, describe its transaction and clock assumptions.
+
+Use synthetic data. Report security concerns through private vulnerability reporting.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,32 @@ name: Journal checks
 on: [push, pull_request]
 permissions:
   contents: read
+concurrency:
+  group: checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node: ['24.15.0', '26']
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          node-version: '24.15.0'
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm run check
       - run: npm run benchmark
-      - run: npm pack --dry-run
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: crash-matrix-${{ matrix.os }}
+          name: crash-matrix-${{ matrix.os }}-node-${{ matrix.node }}
           path: artifacts/crash-matrix.json
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.1.1
+
+- Reject malformed persisted recovery policies and noncanonical receipts before
+  they can trigger a retry or replay. Validate records before storing them.
+- Bound canonical JSON while encoding, including shared-object expansion, and
+  reject proxies without invoking their traps.
+- Reject nested and asynchronous store callbacks consistently. Preserve the
+  primary transaction error when rollback fails and close unusable connections.
+- Exercise renewal, settlement, multiple action identities and reopening in
+  independent memory and SQLite state models with explicit boundary coverage.
+- Add a downstream-idempotency-only control and distinguish calls from effects
+  in the 100-case experiment, including response loss without a process kill.
+- Demonstrate a real HTTP socket loss after a separate downstream commit, with
+  bounded transport handling and manual recovery that preserves uncertainty.
+- Check seven targeted mutations and install the actual package in a fresh
+  offline consumer, including a public TypeScript API check.
+- Run Linux, Windows and macOS checks on Node 24.15 and 26; pin Actions by commit,
+  and add dependency updates and issue/review templates.
+
 ## 0.1.0
 
 - Intent binding, lease takeover, fenced completion, renewal and explicit manual settlement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,14 @@ Run `npm ci` and `npm run check` on Node.js 24.15+. Include a reproducing sequen
 for changes to lease or recovery behavior. For concurrency bugs, a process test
 with an explicit rendezvous is more useful than a timing-dependent sleep.
 
+`npm run check` also installs the archive into an isolated offline consumer and
+type-checks its public API. The model tests print fast-check's seed and shrink path
+on failure; include both when reporting a sequence-dependent bug.
+
 Keep changes bounded. New storage adapters need the same conflict, fencing,
-reopen and crash tests as SQLite. Describe any weaker guarantees. Changes to
+reopen and crash tests as SQLite. The present Store contract is synchronous;
+an asynchronous database needs an API design change, not a cast hiding a Promise.
+Describe any weaker guarantees. Changes to
 identity or retention semantics need a migration proposal before implementation.
 
 AI-assisted contributions are welcome. Authors remain responsible for the patch

--- a/README.md
+++ b/README.md
@@ -19,19 +19,38 @@ npm run demo
 ```
 
 The demo kills a real child process after it commits to a separate synthetic
-ledger, then starts another process to recover. It compares four approaches:
+ledger, then starts another process to recover. It compares five approaches:
 
 | Approach | Recovery after the effect, before recording completion |
 |---|---|
 | Retry without a journal | Repeats the effect |
 | Completion checkpoint | Repeats the effect |
+| Downstream idempotency alone | Retrieves the original receipt through another call |
 | Journal + downstream idempotency | Retrieves the original receipt |
 | Journal + manual recovery | Stops with `indeterminate` |
+
+Downstream idempotency prevents duplicate effects in both idempotent strategies.
+The journal additionally coordinates live execution, detects changed intent and
+replays completed receipts without contacting the service. The experiment measures
+service calls and effects separately so those benefits are not conflated.
 
 This is a correctness experiment with an injected logical clock, not a throughput
 benchmark or a claim about any model's performance. [Protocol and raw results](docs/experiments.md).
 
 Engineering note: [The receipt that did not arrive](docs/lost-receipt.md).
+
+For the same failure over a real loopback HTTP connection, run `npm run demo:http`.
+The synthetic service commits to its own SQLite database and closes the socket
+before returning a receipt. Idempotent recovery makes two HTTP calls for one
+effect, then replays locally; manual recovery keeps the outcome indeterminate
+after one call. [Integration code](examples/http/client.ts) handles bounded
+responses and an absolute request deadline without hidden transport retries.
+The [HTTP tests](tests/http-recovery.test.ts) also reopen both databases and
+reject receipts that arrive after lease expiry. This is a local example, not
+a hosted service or a production network adapter. Client and service run in one
+process; HTTP tests reopen stores normally, while the separate process tests
+exercise forced termination. Network deadlines do not include synchronous
+SQLite lock waits.
 
 ## Use the journal
 
@@ -96,16 +115,22 @@ Read the [failure contract](docs/contract.md) before integrating.
 1. [State transitions](src/journal.ts): acquisition, expiry, uncertainty, settlement.
 2. [Storage transaction](src/sqlite.ts): local durability and serialized claims.
 3. [Process tests](tests/process.test.ts): kill points and concurrent contenders.
-4. [Independent model](tests/model.test.ts): 1,000 seeded operation histories.
+4. [Independent model](tests/model.test.ts): 500 memory and 40 SQLite histories,
+   plus exact-boundary walks through renewal, settlement, conflicts and reopening.
+5. [Storage integrity](tests/integrity.test.ts): malformed records, failed rollback,
+   bounded JSON and invalid transaction callbacks.
 
 ```sh
-npm run check           # tests, targeted mutations, public-tree checks
-npm run benchmark       # 60 crash/recovery scenarios; writes artifacts/crash-matrix.json
+npm run check           # tests, targeted mutations, public-tree and package checks
+npm run benchmark       # 100 controlled cases; writes artifacts/crash-matrix.json
 npm pack               # compiled library + docs; no fixtures or local databases
 ```
 
-The targeted mutation check removes four safeguards, one at a time, and requires
-an assertion failure for each. It is not a whole-project mutation score.
+The targeted mutation check removes seven safeguards, one at a time, and requires
+an assertion failure for each. It is not a whole-project mutation score. The package
+check installs the real archive offline in a fresh project, exercises SQLite reopen
+through the public exports, and compiles a TypeScript consumer. CI runs on Linux,
+Windows and macOS with the minimum supported Node 24 release and Node 26.
 
 ## Project scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,16 @@ This package coordinates cooperating local callers. A lease is not an access
 control boundary and a scope is not a tenant authorization check. Do not expose
 the journal API directly to untrusted clients.
 
+Persisted records are structurally validated before use, including canonical
+receipt data and size bounds. Validation does not authenticate the database or
+detect a forged but valid record. Protect filesystem access and backups. Results
+are plaintext; return only the receipt fields needed for recovery.
+
+The JSON encoder rejects proxies and accessors without invoking them and stops at
+its output budget. Callers still need admission control and request/body limits
+before parsing untrusted input. A local synchronous lock wait can block the event
+loop; the five-second busy timeout is a bound, not an availability guarantee.
+
 For a suspected vulnerability, use this repository's GitHub private vulnerability
 reporting feature when enabled. Do not post credentials, private databases or user
 traces in a public issue. Include a minimal synthetic reproduction.

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -3,35 +3,40 @@ import { tmpdir, platform, arch, release } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { runWorker, effectCount } from '../tests/fixtures/process.js';
+import assert from 'node:assert/strict';
+import { runWorker, ledgerCounts, faultPhases, strategies } from '../tests/fixtures/process.js';
 
-const rows: { repetition: number; strategy: string; phase: string; outcome: string; effects: number }[] = [];
-const phases = ['before-effect', 'after-effect', 'after-complete'];
-const strategies = ['naive', 'checkpoint', 'journal-idempotent', 'journal-manual'];
+const rows: { repetition: number; strategy: string; phase: string; initialOutcome: string; outcome: string; calls: number; effects: number }[] = [];
 for (let repetition = 0; repetition < 5; repetition++) {
-  for (const strategy of strategies) for (const phase of phases) {
+  for (const strategy of strategies) for (const phase of faultPhases) {
     const dir = mkdtempSync(join(tmpdir(), 'journal-bench-'));
     try {
       const journal = join(dir, 'journal.sqlite'), ledger = join(dir, 'ledger.sqlite');
-      await runWorker(journal, ledger, strategy, phase);
+      const initial = await runWorker(journal, ledger, strategy, phase);
+      assert.equal(initial.kind, phase === 'response-loss' ? 'response-lost' : 'paused');
       const result = await runWorker(journal, ledger, strategy, 'none', 111);
-      rows.push({ repetition, strategy, phase, outcome: result.kind, effects: effectCount(ledger) });
+      rows.push({ repetition, strategy, phase, initialOutcome: initial.kind, outcome: result.kind, ...ledgerCounts(ledger) });
     } finally { rmSync(dir, { recursive: true, force: true }); }
   }
 }
 let commit = 'uncommitted';
-try { commit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); } catch { /* An unpacked source archive has no Git metadata. */ }
+let workingTreeDirty: boolean | null = null;
+try {
+  commit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  workingTreeDirty = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim().length > 0;
+} catch { /* An unpacked source archive has no Git metadata. */ }
 const output = {
-  protocol: 1, createdAt: new Date().toISOString(), commit,
+  protocol: 2, createdAt: new Date().toISOString(), commit, workingTreeDirty,
   environment: { node: process.version, platform: platform(), arch: arch(), osRelease: release() },
   lockSha256: createHash('sha256').update(readFileSync('package-lock.json')).digest('hex'),
-  clock: 'Injected logical milliseconds; acquire=100, recover=111, lease=10. Processes are really killed.',
+  clock: 'Injected logical milliseconds; acquire=100, recover=111, lease=10. The three pause phases kill real processes; response-loss exits without delivering a committed receipt.',
+  downstream: 'Both idempotent strategies use the identical stable action key and a durable deduplicating synthetic service. Calls count accepted requests, including deduplicated requests; effects count service commits.',
   repetitions: 5, scenarios: rows.length, rows,
 };
 mkdirSync('artifacts', { recursive: true });
 writeFileSync('artifacts/crash-matrix.json', JSON.stringify(output, null, 2) + '\n');
 console.table(strategies.map(strategy => {
   const selected = rows.filter(r => r.strategy === strategy);
-  return { strategy, scenarios: selected.length, duplicates: selected.filter(r => r.effects > 1).length, indeterminate: selected.filter(r => r.outcome === 'indeterminate').length, confirmed: selected.filter(r => ['completed', 'replay'].includes(r.outcome)).length };
+  return { strategy, scenarios: selected.length, calls: selected.reduce((total, r) => total + r.calls, 0), effects: selected.reduce((total, r) => total + r.effects, 0), duplicates: selected.filter(r => r.effects > 1).length, indeterminate: selected.filter(r => r.outcome === 'indeterminate').length, confirmed: selected.filter(r => ['completed', 'replay'].includes(r.outcome)).length };
 }));
 console.log('Raw results: artifacts/crash-matrix.json');

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -63,8 +63,17 @@ this is not a high-throughput adapter. Busy lock waits are bounded to five secon
 
 Use one database on local disk, with filesystem locking supported by SQLite.
 Network filesystems and replicated database copies are unsupported. The memory
-adapter has neither process coordination nor crash durability. Disk corruption
-and unsupported schema versions throw; they never become a fresh journal.
+adapter has neither process coordination nor crash durability. Records with invalid
+field types, unknown fields, impossible state combinations or noncanonical results
+throw; they never become a fresh journal. This validates structure, not authenticity:
+someone who can rewrite the database can also forge a structurally valid receipt.
+
+Both adapters reject nested transactions and asynchronous callbacks. The callback
+must return a `Change` synchronously. Rejection prevents a returned change from being
+committed; it cannot cancel arbitrary JavaScript side effects in a misused callback.
+If rollback itself fails, SQLite closes that connection and throws an `AggregateError`
+preserving the original failure. Open a fresh adapter only after diagnosing the
+storage failure. A failed completion still means its external effect may have occurred.
 
 Processes use the same host wall clock by default. Large clock jumps affect
 availability and expiry; this is not a distributed lease service. Time is sampled
@@ -78,6 +87,10 @@ database and choose result contents accordingly. v0.1 performs no authentication
 encryption, retention cleanup or secure erasure.
 
 Canonical JSON sorts object keys, preserves array order and rejects unsupported
-values, accessors, sparse arrays and cycles. Negative zero normalizes to zero.
-Depth is limited to 64 and encoded size to 1 MiB. These limits do not make the API
-a sandbox for hostile JavaScript objects or prevent pre-encoding memory pressure.
+values, accessors, proxies, sparse arrays and cycles. Negative zero normalizes to zero.
+Depth is limited to 64 and encoded size to 1 MiB. Encoding stops as the byte budget
+is consumed, including when a small shared object graph would expand exponentially.
+Persisted receipts must meet the same domain and canonical encoding. The outer
+record has a separate size bound because the nested JSON string escapes again.
+These checks do not replace request limits: the caller has already allocated the
+input object, and this synchronous API is not a sandbox for arbitrary JavaScript.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -18,31 +18,60 @@ receipt after causing a duplicate. The manual strategy has five cases that stop
 before any effect and five that stop after one effect; neither group is guessed
 to be successful. [Download the local raw matrix](https://github.com/RaycarlLei/tool-journal/releases/download/v0.1.0/crash-matrix.json).
 
-## Reproduce
+## Current protocol (2)
 
-Run `npm run benchmark`. It executes four strategies at three kill points, repeated
-five times: 60 cases and 120 child-process launches. Each case has fresh journal
-and downstream SQLite files. Every pause is acknowledged over IPC, then the parent
-terminates that child before starting recovery.
+Run `npm run benchmark`. It executes five strategies at four controlled boundaries,
+repeated five times: 100 cases, representing 20 distinct strategy/boundary pairs.
+Each case has fresh journal and downstream SQLite files. A process pause is
+acknowledged over IPC before the parent terminates the child and starts recovery.
 
 Kill points: before the effect, after committing the effect, and after recording
-completion. The clock is logical: acquisition at 100 ms, lease expiry at 110 ms,
+completion. A fourth case drops the response after the effect, reports the transport
+failure, and starts a new recovery process. The clock is logical: acquisition at 100 ms, lease expiry at 110 ms,
 recovery at 111 ms. No actual ten-millisecond timing claim is made. POSIX uses
 SIGKILL; Node forcefully terminates the process on Windows.
 
 The baselines are small implementations included in [worker.ts](../tests/fixtures/worker.ts):
-naive retry has no completion record; checkpoint records completion only; journal
-uses the library with either a key-deduplicating downstream or manual recovery.
-This comparison does not isolate journal performance: the downstream idempotency
-contract is an essential additional capability, explicitly shown in the label.
+naive retry has no completion record; checkpoint records completion only;
+downstream-idempotency-only passes the same stable action key used by journal-idempotent
+but has no journal; journal uses the library with either that downstream contract or
+manual recovery. Both idempotent strategies prevent duplicate effects in this fixture.
+That property belongs to the downstream contract, not to journal storage alone.
 
-The report counts external effects separately from completed/replayed outcomes.
+The journal suppresses service calls after completion has been durably recorded.
+Separate process tests verify suppression while another executor holds a live lease,
+and verify that an old executor can still reach the downstream even though its journal
+completion is rejected. Manual uncertainty cannot cancel a request already in flight.
+
+The report counts service calls and external effects separately from completed/replayed outcomes.
 An indeterminate action is never counted as confirmed success. Five repetitions
 check consistency at these controlled boundaries; they are not confidence
 intervals or evidence about the frequency of real-world failures. The matrix is
 public and deterministic, not a hidden evaluation set.
 
 `artifacts/crash-matrix.json` records each case, runtime/OS, lockfile hash and source
-commit. Release assets include the recorded run. CI runs the same matrix and
-uploads its report. The independent property test uses seed 20260907 for 1,000
-operation histories; counterexamples are shrunk by fast-check when a test fails.
+commit and whether tracked changes were present. Release assets include the recorded
+run. CI runs the same matrix and uploads its report. Historical protocol 1 results
+above remain tied to the original release and must not be relabeled as protocol 2.
+
+The independent model uses seed 20260908 for 500 MemoryStore histories and 40 SQLite
+histories of up to 100 commands. Each adapter also runs a 23-command exact-boundary
+walk, and coverage assertions require 26 observable protocol paths. Commands cover
+renewal, settlement, input/result mutation, old handles, multiple namespaces,
+rollback and connection reopening. fast-check shrinks failing random sequences.
+This is bounded model-based testing, not an exhaustive proof of all interleavings.
+
+## HTTP receipt loss
+
+`npm run demo:http` uses a real IPv4 loopback connection and two independent
+SQLite files. The service commits its effect, then closes the socket before
+response headers. The idempotent example recovers the same receipt on its next
+call and replays it locally afterward: two HTTP calls, one effect. The manual
+example makes one call and reports uncertainty after lease expiry.
+
+The client makes one attempt with an absolute network deadline, a response-byte
+limit and receipt validation. Tests cover malformed and oversized messages,
+redirect rejection, expired receipts and reopening both stores. The service and
+client share a process in this integration fixture. Reopening is orderly; the
+separate process tests above provide the forced-termination evidence. Neither
+fixture demonstrates cross-host availability or a production service SLA.

--- a/docs/lost-receipt.md
+++ b/docs/lost-receipt.md
@@ -37,6 +37,12 @@ idempotency. A local journal alone cannot provide this property for an arbitrary
 remote service. An API whose idempotency keys expire sooner than retries can occur
 would also violate the contract.
 
+The current experiment includes downstream idempotency without a journal, using
+exactly the same key. It also avoids duplicate effects. The journal adds a durable
+local receipt, live-lease coordination and changed-intent detection; after completion
+is recorded, replay no longer needs another service call. The original v0.1.0 matrix
+did not isolate those responsibilities and is retained as a historical result.
+
 ## What an old executor can still do
 
 A lease can expire while a process is paused. A new process then takes over with
@@ -63,8 +69,8 @@ no reset button that silently turns uncertainty into permission to execute again
 
 ## What the experiment establishes
 
-The [recorded matrix](experiments.md) covers three chosen kill points on local
-SQLite files. It demonstrates the implemented protocol at those boundaries.
+The [experiment](experiments.md) covers three chosen kill points and one response-loss
+boundary on local SQLite files. It demonstrates the implemented protocol there.
 The seeded model tests explore additional operation sequences, and the targeted
 mutations verify that selected safeguards are actually tested. None of these
 establish a production failure rate, power-loss durability or correctness for an

--- a/examples/crash-recovery.ts
+++ b/examples/crash-recovery.ts
@@ -1,14 +1,20 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { runWorker, effectCount } from '../tests/fixtures/process.js';
+import { runWorker, ledgerCounts, strategies } from '../tests/fixtures/process.js';
 
 const dir = mkdtempSync(join(tmpdir(), 'journal-demo-'));
 try {
-  for (const strategy of ['naive', 'checkpoint', 'journal-idempotent', 'journal-manual']) {
+  for (const strategy of strategies) {
     const journal = join(dir, `${strategy}.sqlite`), ledger = join(dir, `${strategy}-ledger.sqlite`);
     await runWorker(journal, ledger, strategy, 'after-effect');
     const recovery = await runWorker(journal, ledger, strategy, 'none', 111);
-    console.log(JSON.stringify({ strategy, crash: 'after-effect-before-receipt', recovery: recovery.kind, effects: effectCount(ledger) }));
+    const afterRecovery = ledgerCounts(ledger);
+    const restarted = await runWorker(journal, ledger, strategy, 'none', 200);
+    console.log(JSON.stringify({
+      strategy, crash: 'after-effect-before-receipt', recovery: recovery.kind,
+      ...afterRecovery, nextRestart: restarted.kind,
+      additionalCallsOnRestart: ledgerCounts(ledger).calls - afterRecovery.calls,
+    }));
   }
 } finally { rmSync(dir, { recursive: true, force: true }); }

--- a/examples/http-recovery.ts
+++ b/examples/http-recovery.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Journal, SqliteStore, type Intent } from '../src/index.js';
+import { appendWithJournal } from './http/client.js';
+import { startSyntheticService } from './http/service.js';
+
+// No credentials, arbitrary URLs, or real-world side effects. The two SQLite
+// files are independent, and the receipt really crosses a loopback HTTP socket.
+const dir = mkdtempSync(join(tmpdir(), 'journal-http-demo-'));
+try {
+  for (const recovery of ['idempotent', 'manual'] as const) {
+    const service = await startSyntheticService(join(dir, `${recovery}-downstream.sqlite`));
+    let store: SqliteStore | undefined;
+    try {
+      store = new SqliteStore(join(dir, `${recovery}-journal.sqlite`));
+      let now = 100;
+      const journal = new Journal(store, () => now);
+      const intent: Intent = { scope: 'http-demo', key: 'append-seven', tool: 'append', input: { units: 7 }, recovery };
+      service.dropNextReply(recovery);
+      const first = await appendWithJournal(journal, service.port, intent, 10);
+      assert.equal(first.kind, 'unconfirmed');
+      const committed = service.snapshot();
+      assert.equal(committed.effects, 1);
+      now = 111; // Logical clock: expire the 10 ms lease without a timing race.
+      const retried = await appendWithJournal(journal, service.port, intent, 10);
+      const repeated = await appendWithJournal(journal, service.port, intent, 10);
+      const final = service.snapshot();
+      assert.equal(retried.kind, recovery === 'idempotent' ? 'completed' : 'indeterminate');
+      assert.equal(repeated.kind, recovery === 'idempotent' ? 'replay' : 'indeterminate');
+      assert.equal(final.effects, 1);
+      assert.equal(final.calls, recovery === 'idempotent' ? 2 : 1);
+      console.log(JSON.stringify({ recovery, first: first.kind, retry: retried.kind, repeat: repeated.kind, calls: final.calls, effects: final.effects }));
+    } finally {
+      store?.close();
+      await service.close();
+    }
+  }
+} finally { rmSync(dir, { recursive: true, force: true }); }

--- a/examples/http/client.ts
+++ b/examples/http/client.ts
@@ -1,0 +1,110 @@
+import { request } from 'node:http';
+import { Journal, type Begin, type Intent, type Recovery } from '../../src/index.js';
+
+export type Receipt = { receipt: number; units: number };
+export const MAX_RESPONSE_BYTES = 4_096;
+const REQUEST_TIMEOUT_MS = 2_000;
+type FailureReason = 'transport' | 'http' | 'invalid-response';
+
+export class ReceiptUnavailable extends Error {
+  constructor(readonly reason: FailureReason) {
+    super(`Downstream receipt unavailable: ${reason}`);
+  }
+}
+
+function validatePort(port: number): void {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) throw new TypeError('Expected a loopback service port');
+}
+
+/** One request, fixed loopback address, no redirects or transport retries. */
+export function requestReceipt(
+  port: number, recovery: Recovery, units: number, key?: string, timeoutMs = REQUEST_TIMEOUT_MS,
+): Promise<Receipt> {
+  validatePort(port);
+  if (!Number.isSafeInteger(units) || units < 1 || units > 1_000) throw new TypeError('Expected 1 to 1000 synthetic units');
+  if (recovery !== 'idempotent' && recovery !== 'manual') throw new TypeError('Invalid recovery contract');
+  if ((recovery === 'idempotent' && !/^[a-f0-9]{64}$/.test(key ?? '')) || (recovery === 'manual' && key !== undefined)) {
+    throw new TypeError('Only the idempotent endpoint accepts a stable action key');
+  }
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > REQUEST_TIMEOUT_MS) throw new TypeError('Invalid request deadline');
+  // The fixed schema also bounds the outbound body: at most 14 ASCII bytes.
+  const body = JSON.stringify({ units });
+  return new Promise<Receipt>((resolve, reject) => {
+    const req = request({
+      host: '127.0.0.1', port, path: `/${recovery}`, method: 'POST', agent: false,
+      maxHeaderSize: 8_192,
+      headers: {
+        'content-type': 'application/json', 'content-length': Buffer.byteLength(body),
+        ...(key ? { 'idempotency-key': key } : {}),
+      },
+    });
+    let settled = false;
+    const deadline = setTimeout(() => fail('transport'), timeoutMs);
+    function fail(reason: FailureReason): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      req.destroy();
+      reject(new ReceiptUnavailable(reason));
+    }
+    req.once('error', () => fail('transport'));
+    req.once('response', res => {
+      res.once('error', () => fail('transport'));
+      res.once('aborted', () => fail('transport'));
+      if (res.statusCode !== 200) { fail('http'); return; }
+      const length = Number(res.headers['content-length']);
+      if (res.headers['content-type'] !== 'application/json' || (Number.isFinite(length) && length > MAX_RESPONSE_BYTES)) {
+        fail('invalid-response');
+        return;
+      }
+      const chunks: Buffer[] = [];
+      let bytes = 0;
+      res.on('data', (chunk: Buffer) => {
+        bytes += chunk.length;
+        if (bytes > MAX_RESPONSE_BYTES) { fail('invalid-response'); return; }
+        chunks.push(chunk);
+      });
+      res.once('end', () => {
+        if (settled) return;
+        try {
+          const receipt: unknown = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+          if (typeof receipt !== 'object' || receipt === null || Array.isArray(receipt) ||
+              Object.keys(receipt).sort().join(',') !== 'receipt,units') throw new Error('Invalid receipt');
+          const value = receipt as Receipt;
+          if (!Number.isSafeInteger(value.receipt) || value.receipt < 1 || value.units !== units) throw new Error('Invalid receipt');
+          settled = true;
+          clearTimeout(deadline);
+          resolve(value);
+        } catch { fail('invalid-response'); }
+      });
+    });
+    req.end(body);
+  });
+}
+
+export type Dispatch = Exclude<Begin, { kind: 'acquired' }>
+  | { kind: 'completed' | 'replayed' | 'stale'; result: Receipt }
+  | { kind: 'unconfirmed'; reason: FailureReason };
+
+/** A caller decides when to try again; this function never loops or settles uncertainty. */
+export async function appendWithJournal(journal: Journal, port: number, intent: Intent, leaseMs = 5_000): Promise<Dispatch> {
+  validatePort(port);
+  const input = intent.input;
+  if (typeof input !== 'object' || input === null || Array.isArray(input) || Object.keys(input).join(',') !== 'units' ||
+      typeof input.units !== 'number' || !Number.isSafeInteger(input.units) || input.units < 1 || input.units > 1_000) {
+    throw new TypeError('Expected an input containing only 1 to 1000 synthetic units');
+  }
+  const begun = journal.begin(intent, leaseMs);
+  if (begun.kind !== 'acquired') return begun;
+  let receipt: Receipt;
+  try {
+    receipt = await requestReceipt(port, intent.recovery, input.units, intent.recovery === 'idempotent' ? begun.lease.id : undefined);
+  } catch (error) {
+    if (!(error instanceof ReceiptUnavailable)) throw error;
+    // A timeout, invalid response, or non-success status is not evidence that
+    // the downstream did nothing. Leave the durable pending record intact.
+    return { kind: 'unconfirmed', reason: error.reason };
+  }
+  // Storage failures escape. Never claim a receipt was journaled if this fails.
+  return { ...journal.complete(begun.lease, receipt), result: receipt };
+}

--- a/examples/http/service.ts
+++ b/examples/http/service.ts
@@ -1,0 +1,151 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { DatabaseSync } from 'node:sqlite';
+import { performance } from 'node:perf_hooks';
+import type { Recovery } from '../../src/index.js';
+import type { Receipt } from './client.js';
+
+export const MAX_REQUEST_BYTES = 1_024;
+class HttpError extends Error {
+  constructor(readonly status: number) { super(`Synthetic service rejected request (${status})`); }
+}
+
+async function readUnits(req: IncomingMessage, bodyTimeoutMs: number): Promise<number> {
+  if (req.headers['content-type'] !== 'application/json') throw new HttpError(415);
+  if (Number(req.headers['content-length']) > MAX_REQUEST_BYTES) throw new HttpError(413);
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  const expiresAt = performance.now() + bodyTimeoutMs;
+  // This deadline is never refreshed by body progress. The monotonic check
+  // also rejects a late body if event-loop delay postpones the timer callback.
+  const deadline = setTimeout(() => req.destroy(), bodyTimeoutMs);
+  function checkDeadline(): void {
+    if (performance.now() >= expiresAt) {
+      req.destroy();
+      throw new HttpError(408);
+    }
+  }
+  try {
+    for await (const chunk of req) {
+      checkDeadline();
+      const buffer = Buffer.from(chunk as Uint8Array);
+      bytes += buffer.length;
+      if (bytes > MAX_REQUEST_BYTES) throw new HttpError(413);
+      chunks.push(buffer);
+    }
+    checkDeadline();
+  } finally {
+    clearTimeout(deadline);
+  }
+  let value: unknown;
+  try { value = JSON.parse(Buffer.concat(chunks).toString('utf8')); } catch { throw new HttpError(400); }
+  if (typeof value !== 'object' || value === null || Array.isArray(value) || Object.keys(value).join(',') !== 'units') throw new HttpError(400);
+  const units = (value as { units: unknown }).units;
+  if (typeof units !== 'number' || !Number.isSafeInteger(units) || units < 1 || units > 1_000) throw new HttpError(400);
+  return units;
+}
+
+export interface SyntheticService {
+  readonly port: number;
+  dropNextReply(recovery: Recovery): void;
+  snapshot(): { calls: number; effects: number; receipts: (Receipt & { key: string | null })[] };
+  close(): Promise<void>;
+}
+
+/** Test ledger only: binds IPv4 loopback and never contacts another service. */
+export async function startSyntheticService(path: string, bodyTimeoutMs = 2_000): Promise<SyntheticService> {
+  if (!Number.isSafeInteger(bodyTimeoutMs) || bodyTimeoutMs < 1 || bodyTimeoutMs > 2_000) {
+    throw new TypeError('Body deadline must be an integer from 1 to 2000 milliseconds');
+  }
+  const db = new DatabaseSync(path, { timeout: 2_000 });
+  try {
+    db.exec(`
+      PRAGMA journal_mode=WAL;
+      PRAGMA synchronous=FULL;
+      CREATE TABLE IF NOT EXISTS effects (receipt INTEGER PRIMARY KEY, key TEXT UNIQUE, units INTEGER NOT NULL) STRICT;
+      CREATE TABLE IF NOT EXISTS requests (attempt INTEGER PRIMARY KEY, key TEXT) STRICT;
+    `);
+  } catch (error) { db.close(); throw error; }
+
+  const droppedReplies = new Set<Recovery>();
+  const pending = new Set<Promise<void>>();
+  const server = createServer({ maxHeaderSize: 8_192, headersTimeout: 1_000, requestTimeout: 2_000 }, (req, res) => {
+    const task = handle(req, res);
+    pending.add(task);
+    void task.then(() => pending.delete(task), () => { pending.delete(task); res.destroy(); });
+  });
+  server.maxHeadersCount = 32;
+  server.setTimeout(2_000, socket => socket.destroy());
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      if (req.method !== 'POST' || (req.url !== '/idempotent' && req.url !== '/manual')) throw new HttpError(404);
+      const recovery: Recovery = req.url === '/idempotent' ? 'idempotent' : 'manual';
+      const header = req.headers['idempotency-key'];
+      if ((recovery === 'idempotent' && (typeof header !== 'string' || !/^[a-f0-9]{64}$/.test(header))) ||
+          (recovery === 'manual' && header !== undefined)) throw new HttpError(400);
+      const units = await readUnits(req, bodyTimeoutMs);
+      if (!req.complete || res.destroyed) return;
+      const key = typeof header === 'string' ? header : null;
+      let receipt: Receipt;
+      db.exec('BEGIN IMMEDIATE');
+      try {
+        db.prepare('INSERT INTO requests(key) VALUES (?)').run(key);
+        const prior = key === null ? undefined : db.prepare('SELECT receipt, units FROM effects WHERE key = ?').get(key);
+        if (prior && prior.units !== units) {
+          db.exec('COMMIT');
+          throw new HttpError(409);
+        }
+        if (!prior) db.prepare('INSERT INTO effects(key, units) VALUES (?, ?)').run(key, units);
+        const id = prior ? Number(prior.receipt) : Number(db.prepare('SELECT last_insert_rowid() AS id').get()!.id);
+        receipt = { receipt: id, units };
+        db.exec('COMMIT');
+      } catch (error) { if (db.isTransaction) db.exec('ROLLBACK'); throw error; }
+
+      if (droppedReplies.delete(recovery)) {
+        // This is the only fault injection: the independent service committed,
+        // then the real TCP connection closes before HTTP response headers.
+        res.destroy();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json', connection: 'close' });
+      res.end(JSON.stringify(receipt));
+    } catch (error) {
+      if (!res.destroyed) {
+        res.writeHead(error instanceof HttpError ? error.status : 500, { connection: 'close' });
+        res.end();
+      }
+    }
+  }
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => { server.off('error', reject); resolve(); });
+    });
+  } catch (error) { db.close(); throw error; }
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected a loopback TCP listener');
+  let closing: Promise<void> | undefined;
+  return {
+    port: address.port,
+    dropNextReply(recovery) { droppedReplies.add(recovery); },
+    snapshot() {
+      const receipts = db.prepare('SELECT receipt, key, units FROM effects ORDER BY receipt').all()
+        .map(row => ({ receipt: Number(row.receipt), key: row.key === null ? null : String(row.key), units: Number(row.units) }));
+      return { calls: Number(db.prepare('SELECT count(*) AS n FROM requests').get()!.n), effects: receipts.length, receipts };
+    },
+    close() {
+      return closing ??= (async () => {
+        try {
+          await new Promise<void>((resolve, reject) => {
+            server.close(error => error ? reject(error) : resolve());
+            server.closeAllConnections();
+          });
+        } finally {
+          await Promise.allSettled(pending);
+          db.close();
+        }
+      })();
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycarllei/tool-journal",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "24.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Durable tool execution with lease fencing, explicit uncertainty, and reproducible crash tests.",
   "license": "MIT",
   "type": "module",
@@ -12,10 +12,12 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test dist/tests/*.test.js",
     "demo": "npm run build && node dist/examples/crash-recovery.js",
+    "demo:http": "npm run build && node dist/examples/http-recovery.js",
     "benchmark": "npm run build && node dist/benchmarks/run.js",
     "test:mutations": "npm run build && node scripts/mutations.mjs",
     "check:public": "node scripts/check-public.mjs",
-    "check": "npm test && npm run test:mutations && npm run check:public",
+    "check:package": "npm run build && node scripts/check-package.mjs",
+    "check": "npm test && npm run test:mutations && npm run check:public && npm run check:package",
     "prepack": "npm run build"
   },
   "devDependencies": { "@types/node": "24.10.1", "fast-check": "4.3.0", "typescript": "5.9.3" }

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const npm = process.env.npm_execpath;
+assert.ok(npm, 'Run this check through npm run check:package');
+const tempRoot = resolve(tmpdir());
+const directory = mkdtempSync(join(tempRoot, 'tool-journal-package-'));
+const manifest = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies', 'bundledDependencies', 'bundleDependencies']) {
+  const value = manifest[field];
+  assert.ok(value === undefined || (value !== null && typeof value === 'object' && Object.keys(value).length === 0),
+    `Runtime dependency policy violated: ${field}`);
+}
+function run(args, cwd = directory) {
+  return execFileSync(process.execPath, args, {
+    cwd, encoding: 'utf8', windowsHide: true, timeout: 60_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+try {
+  const [archive] = JSON.parse(run([npm, 'pack', '--ignore-scripts', '--json', '--pack-destination', directory], root));
+  const names = archive.files.map(file => file.path);
+  assert.ok(names.includes('dist/src/index.js'));
+  assert.ok(names.includes('dist/src/index.d.ts'));
+  for (const name of names) {
+    assert.ok(/^(?:dist\/src\/[a-z-]+\.(?:js|d\.ts)|docs\/[a-z-]+\.md|package\.json|README\.md|LICENSE)$/.test(name),
+      `Unexpected package member: ${name}`);
+  }
+  // Install only the produced archive, without network access or lifecycle hooks.
+  // Dependency policy is checked explicitly above; a warm cache is not evidence.
+  writeFileSync(join(directory, 'package.json'), JSON.stringify({ private: true, type: 'module' }));
+  run([npm, 'install', '--offline', '--ignore-scripts', '--no-audit', '--no-fund', join(directory, archive.filename)]);
+  const installed = JSON.parse(readFileSync(join(directory, 'node_modules', manifest.name, 'package.json'), 'utf8'));
+  assert.equal(installed.version, manifest.version);
+  for (const hook of ['preinstall', 'install', 'postinstall']) assert.equal(installed.scripts?.[hook], undefined);
+  writeFileSync(join(directory, 'consumer.mjs'), `
+import assert from 'node:assert/strict';
+import { Journal, SqliteStore } from '@raycarllei/tool-journal';
+const intent = { scope: 'package-check', key: 'once', tool: 'append', input: { units: 7 }, recovery: 'idempotent' };
+let store = new SqliteStore('journal.sqlite');
+const journal = new Journal(store, () => 100);
+const begun = journal.begin(intent);
+assert.equal(begun.kind, 'acquired');
+assert.equal(journal.complete(begun.lease, { receipt: 7 }).kind, 'completed');
+store.close();
+store = new SqliteStore('journal.sqlite');
+try { assert.deepEqual(new Journal(store).begin(intent), { kind: 'replay', result: { receipt: 7 } }); }
+finally { store.close(); }
+`);
+  run(['consumer.mjs']);
+  writeFileSync(join(directory, 'consumer.mts'), `
+import { Journal, MemoryStore, type Intent, type Begin } from '@raycarllei/tool-journal';
+const intent: Intent = { scope: 'types', key: 'one', tool: 'append', input: null, recovery: 'manual' };
+const journal = new Journal(new MemoryStore());
+const result: Begin = journal.begin(intent);
+if (result.kind === 'acquired') journal.complete(result.lease, { receipt: 1 });
+`);
+  run([join(root, 'node_modules/typescript/bin/tsc'), '--noEmit', '--strict', '--module', 'NodeNext',
+    '--moduleResolution', 'NodeNext', '--target', 'ES2023', 'consumer.mts']);
+  console.log(`Package ${manifest.name}@${manifest.version}: allowlist, offline install, SQLite reopen and public types passed.`);
+} finally {
+  assert.equal(dirname(resolve(directory)), tempRoot);
+  assert.ok(basename(directory).startsWith('tool-journal-package-'));
+  rmSync(directory, { recursive: true, force: true });
+}

--- a/scripts/mutations.mjs
+++ b/scripts/mutations.mjs
@@ -10,15 +10,19 @@ const faults = [
   ['accept stale execution epochs', 'entry.epoch === lease.epoch && entry.executor === lease.executor', 'true'],
   ['retry an uncertain manual action', "entry.recovery === 'manual'", 'false'],
   ['allow completion after lease expiry', 'entry.leaseUntil <= this.now()', 'false'],
+  ['resurrect an expired lease', "entry.state !== 'pending' || entry.leaseUntil <= now", "entry.state !== 'pending'"],
+  ['shorten a renewed lease', 'Math.max(entry.leaseUntil, deadline)', 'deadline'],
+  ['settle before uncertainty', "entry.state !== 'indeterminate'", 'false'],
 ];
-const baseline = spawnSync(process.execPath, ['--test', 'dist/tests/journal.test.js'], { encoding: 'utf8', windowsHide: true, timeout: 30_000 });
+const tests = ['--test', 'dist/tests/journal.test.js', 'dist/tests/model.test.js', 'dist/tests/integrity.test.js'];
+const baseline = spawnSync(process.execPath, tests, { encoding: 'utf8', windowsHide: true, timeout: 30_000 });
 if (baseline.status !== 0) throw new Error('Baseline tests must pass before mutation checks');
 let failed = false;
 try {
   for (const [name, needle, replacement] of faults) {
     if (!original.includes(needle)) throw new Error(`Mutation target moved: ${name}`);
     writeFileSync(file, original.replace(needle, replacement));
-    const result = spawnSync(process.execPath, ['--test', 'dist/tests/journal.test.js'], { encoding: 'utf8', windowsHide: true, timeout: 30_000 });
+    const result = spawnSync(process.execPath, tests, { encoding: 'utf8', windowsHide: true, timeout: 30_000 });
     if (result.error || result.signal) throw new Error(`Mutation test did not finish: ${name}`);
     const killed = result.status !== 0 && /AssertionError|ERR_ASSERTION/.test(result.stdout + result.stderr);
     console.log(`${killed ? 'killed' : 'SURVIVED'}: ${name}`);

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,42 +1,66 @@
 import { createHash } from 'node:crypto';
+import { types } from 'node:util';
 
 export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+export const MAX_JSON_BYTES = 1_048_576;
 
 /** A deliberately small JSON domain: no coercion, accessors, cycles or sparse arrays. */
 export function canonical(value: unknown): string {
   const ancestors = new Set<object>();
-  function visit(v: unknown, depth: number): string {
+  const chunks: string[] = [];
+  let bytes = 0;
+  function append(text: string): void {
+    bytes += Buffer.byteLength(text);
+    if (bytes > MAX_JSON_BYTES) throw new TypeError('JSON exceeds 1 MiB');
+    chunks.push(text);
+  }
+  function string(text: string): void {
+    // The encoded byte length cannot be smaller than the UTF-16 code-unit count.
+    // Check before JSON.stringify allocates an escaped copy of a large string.
+    if (text.length > MAX_JSON_BYTES - bytes) throw new TypeError('JSON exceeds 1 MiB');
+    append(JSON.stringify(text));
+  }
+  function visit(v: unknown, depth: number): void {
     if (depth > 64) throw new TypeError('JSON exceeds depth 64');
-    if (v === null || typeof v === 'boolean' || typeof v === 'string') return JSON.stringify(v);
-    if (typeof v === 'number' && Number.isFinite(v)) return JSON.stringify(v);
+    if (typeof v === 'string') { string(v); return; }
+    if (v === null || typeof v === 'boolean') { append(JSON.stringify(v)); return; }
+    if (typeof v === 'number' && Number.isFinite(v)) { append(JSON.stringify(v)); return; }
     if (typeof v !== 'object' || v === null) throw new TypeError('Expected finite JSON data');
+    if (types.isProxy(v)) throw new TypeError('Proxy is not JSON data');
     if (ancestors.has(v)) throw new TypeError('Cyclic JSON');
     ancestors.add(v);
     try {
-      const descriptors = Object.getOwnPropertyDescriptors(v);
-      if (Reflect.ownKeys(v).some(k => typeof k === 'symbol')) throw new TypeError('Symbol key');
+      const keys = Reflect.ownKeys(v);
+      if (keys.some(k => typeof k === 'symbol')) throw new TypeError('Symbol key');
+      if (keys.length > MAX_JSON_BYTES - bytes) throw new TypeError('JSON exceeds 1 MiB');
       if (Array.isArray(v)) {
-        if (Object.keys(descriptors).length !== v.length + 1) throw new TypeError('Sparse or decorated array');
-        const parts: string[] = [];
+        if (keys.length !== v.length + 1) throw new TypeError('Sparse or decorated array');
+        append('[');
         for (let i = 0; i < v.length; i++) {
-          const d = descriptors[String(i)];
+          const d = Object.getOwnPropertyDescriptor(v, String(i));
           if (!d || !('value' in d)) throw new TypeError('Array accessor or hole');
-          parts.push(visit(d.value, depth + 1));
+          if (i) append(',');
+          visit(d.value, depth + 1);
         }
-        return '[' + parts.join(',') + ']';
+        append(']');
+        return;
       }
       const prototype: unknown = Object.getPrototypeOf(v);
       if (prototype !== Object.prototype && prototype !== null) throw new TypeError('Expected plain object');
-      return '{' + Object.keys(descriptors).sort().map(k => {
-        const d = descriptors[k]!;
+      append('{');
+      for (const [index, k] of (keys as string[]).sort().entries()) {
+        const d = Object.getOwnPropertyDescriptor(v, k)!;
         if (!d.enumerable || !('value' in d)) throw new TypeError('Object accessor or hidden field');
-        return JSON.stringify(k) + ':' + visit(d.value, depth + 1);
-      }).join(',') + '}';
+        if (index) append(',');
+        string(k);
+        append(':');
+        visit(d.value, depth + 1);
+      }
+      append('}');
     } finally { ancestors.delete(v); }
   }
-  const encoded = visit(value, 0);
-  if (Buffer.byteLength(encoded) > 1_048_576) throw new TypeError('JSON exceeds 1 MiB');
-  return encoded;
+  visit(value, 0);
+  return chunks.join('');
 }
 
 export function digest(text: string): string {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,12 +1,17 @@
-import { decodeEntry, type Store, type Entry, type Change } from './record.js';
+import { decodeEntry, encodeEntry, validateChange, type Store, type Entry, type Change } from './record.js';
 
 /** Test adapter. No durability and no coordination across processes. */
 export class MemoryStore implements Store {
   private readonly entries = new Map<string, string>();
+  private inTransaction = false;
   transact<T>(id: string, change: (entry: Entry | undefined) => Change<T>): T {
-    const raw = this.entries.get(id);
-    const { value, next } = change(raw === undefined ? undefined : decodeEntry(raw, id));
-    if (next) this.entries.set(id, JSON.stringify(next));
-    return value;
+    if (this.inTransaction) throw new Error('Nested journal transaction');
+    this.inTransaction = true;
+    try {
+      const raw = this.entries.get(id);
+      const { value, next } = validateChange(change(raw === undefined ? undefined : decodeEntry(raw, id)));
+      if (next !== undefined) this.entries.set(id, encodeEntry(next, id));
+      return value;
+    } finally { this.inTransaction = false; }
   }
 }

--- a/src/record.ts
+++ b/src/record.ts
@@ -1,3 +1,6 @@
+import { canonical, MAX_JSON_BYTES } from './json.js';
+import { types } from 'node:util';
+
 export type Recovery = 'idempotent' | 'manual';
 
 export interface Entry {
@@ -14,24 +17,55 @@ export interface Entry {
 
 /** Invalid persisted state must stop execution, never be treated as an empty journal. */
 export function decodeEntry(raw: string, id: string): Entry {
+  // A canonical result is nested as a JSON string, which can double its byte size.
+  const limit = 2 * MAX_JSON_BYTES + 4_096;
+  if (raw.length > limit || Buffer.byteLength(raw) > limit) throw new Error('Corrupt journal entry: oversized record');
   const v: unknown = JSON.parse(raw);
-  if (typeof v !== 'object' || v === null) throw new Error('Corrupt journal entry');
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) throw new Error('Corrupt journal entry');
   const e = v as Record<string, unknown>;
-  if (e.version !== 1 || e.id !== id || !/^[a-f0-9]{64}$/.test(String(e.fingerprint)) ||
-      !['idempotent', 'manual'].includes(String(e.recovery)) ||
-      !['pending', 'completed', 'indeterminate'].includes(String(e.state)) ||
+  const fields = ['version', 'id', 'fingerprint', 'recovery', 'state', 'epoch', 'executor', 'leaseUntil', 'result'];
+  if (Object.keys(e).length !== fields.length || fields.some(field => !Object.hasOwn(e, field)) ||
+      e.version !== 1 || e.id !== id || typeof e.id !== 'string' || !/^[a-f0-9]{64}$/.test(e.id) ||
+      typeof e.fingerprint !== 'string' || !/^[a-f0-9]{64}$/.test(e.fingerprint) ||
+      (e.recovery !== 'idempotent' && e.recovery !== 'manual') ||
+      (e.state !== 'pending' && e.state !== 'completed' && e.state !== 'indeterminate') ||
+      (e.state === 'indeterminate' && e.recovery !== 'manual') ||
       !Number.isSafeInteger(e.epoch) || Number(e.epoch) < 1 ||
-      typeof e.executor !== 'string' || e.executor.length === 0 ||
+      typeof e.executor !== 'string' || e.executor.length === 0 || e.executor.length > 512 ||
       !Number.isSafeInteger(e.leaseUntil) || Number(e.leaseUntil) < 0 ||
       (e.state === 'completed' ? typeof e.result !== 'string' : e.result !== null)) {
     throw new Error('Corrupt journal entry');
   }
-  if (e.state === 'completed') JSON.parse(e.result as string);
+  if (e.state === 'completed') {
+    try {
+      if (canonical(JSON.parse(e.result as string)) !== e.result) throw new Error('Noncanonical result');
+    } catch (cause) {
+      throw new Error('Corrupt journal entry: invalid result', { cause });
+    }
+  }
   return e as unknown as Entry;
 }
 
+export function encodeEntry(entry: Entry, id: string): string {
+  const raw = JSON.stringify(entry);
+  decodeEntry(raw, id);
+  return raw;
+}
+
 export interface Change<T> { value: T; next?: Entry }
+export function validateChange<T>(change: Change<T>): Change<T> {
+  if (types.isPromise(change)) {
+    // Misused async callbacks may reject after we throw; observe that rejection.
+    // This cannot undo arbitrary work the callback itself already performed.
+    void change.catch(() => {});
+    throw new TypeError('Journal transaction callback must be synchronous');
+  }
+  if (typeof change !== 'object' || change === null || !Object.hasOwn(change, 'value')) {
+    throw new TypeError('Journal transaction callback must return a Change');
+  }
+  return change;
+}
 export interface Store {
-  /** Run a synchronous read/modify/write atomically. Throwing rolls back. */
+  /** Run a synchronous read/modify/write atomically. Throwing rolls back; nested transactions are rejected. */
   transact<T>(id: string, change: (entry: Entry | undefined) => Change<T>): T;
 }

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -1,9 +1,10 @@
 import { DatabaseSync } from 'node:sqlite';
-import { decodeEntry, type Store, type Entry, type Change } from './record.js';
+import { decodeEntry, encodeEntry, validateChange, type Store, type Entry, type Change } from './record.js';
 
 /** Local-disk, same-host coordination. Do not put the database on a network filesystem. */
 export class SqliteStore implements Store {
   private readonly db: DatabaseSync;
+  private inTransaction = false;
   constructor(path: string) {
     this.db = new DatabaseSync(path, { timeout: 5_000 });
     try {
@@ -16,26 +17,36 @@ export class SqliteStore implements Store {
       this.db.exec('CREATE TABLE IF NOT EXISTS tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT');
       this.db.exec('COMMIT');
     } catch (error) {
-      if (this.db.isTransaction) this.db.exec('ROLLBACK');
-      this.db.close();
-      throw error;
+      this.abort(error, true);
     }
   }
   transact<T>(id: string, change: (entry: Entry | undefined) => Change<T>): T {
-    this.db.exec('BEGIN IMMEDIATE');
+    if (this.inTransaction) throw new Error('Nested journal transaction');
+    this.inTransaction = true;
     try {
+      this.db.exec('BEGIN IMMEDIATE');
       const row = this.db.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(id);
-      const { value, next } = change(row ? decodeEntry(String(row.entry), id) : undefined);
-      if (next) {
+      const { value, next } = validateChange(change(row ? decodeEntry(String(row.entry), id) : undefined));
+      if (next !== undefined) {
         this.db.prepare('INSERT INTO tool_journal VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET entry=excluded.entry')
-          .run(id, JSON.stringify(next));
+          .run(id, encodeEntry(next, id));
       }
       this.db.exec('COMMIT');
       return value;
     } catch (error) {
-      if (this.db.isTransaction) this.db.exec('ROLLBACK');
-      throw error;
-    }
+      this.abort(error);
+    } finally { this.inTransaction = false; }
   }
-  close(): void { this.db.close(); }
+  private abort(error: unknown, close = false): never {
+    const failures = [error];
+    try { if (this.db.isTransaction) this.db.exec('ROLLBACK'); }
+    catch (rollback) { failures.push(rollback); close = true; }
+    // A connection whose rollback failed cannot be trusted for another claim.
+    if (close) {
+      try { this.db.close(); } catch (cleanup) { failures.push(cleanup); }
+    }
+    if (failures.length > 1) throw new AggregateError(failures, 'Journal storage cleanup failed', { cause: error });
+    throw error;
+  }
+  close(): void { if (this.db.isOpen) this.db.close(); }
 }

--- a/tests/fixtures/process.ts
+++ b/tests/fixtures/process.ts
@@ -2,30 +2,85 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { DatabaseSync } from 'node:sqlite';
 
+export const strategies = ['naive', 'checkpoint', 'downstream-idempotency-only', 'journal-idempotent', 'journal-manual'] as const;
+export const faultPhases = ['before-effect', 'after-effect', 'after-complete', 'response-loss'] as const;
+export type Strategy = typeof strategies[number];
+export type FaultPhase = typeof faultPhases[number];
 export interface WorkerResult { kind: string; result?: unknown; phase?: string; lease?: { id: string; epoch: number; executor: string } }
-export function runWorker(journal: string, ledger: string, strategy: string, phase = 'none', now = 100): Promise<WorkerResult> {
+export interface LedgerCounts { calls: number; effects: number }
+
+function launchWorker(
+  journal: string, ledger: string, strategy: Strategy | 'claim', phase: FaultPhase | 'none', now: number,
+  whilePaused?: () => Promise<void>, resumeAt = now,
+): Promise<WorkerResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [fileURLToPath(new URL('./worker.js', import.meta.url)), journal, ledger, strategy, phase, String(now)], {
       stdio: ['ignore', 'ignore', 'pipe', 'ipc'], windowsHide: true,
     });
     let result: WorkerResult | undefined;
+    let failure: Error | undefined;
+    let sawPause = false;
     let stderr = '';
-    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('Worker timed out')); }, 15_000);
-    child.stderr!.on('data', chunk => { stderr += String(chunk); });
-    child.once('error', error => { clearTimeout(timer); reject(error); });
+    const timer = setTimeout(() => {
+      failure = new Error(`Worker timed out: ${strategy}/${phase}`);
+      child.kill('SIGKILL');
+    }, 15_000);
+    child.stderr!.on('data', chunk => { stderr = (stderr + String(chunk)).slice(-16_384); });
+    child.once('error', error => { failure = error; });
     child.on('message', message => {
       result = message as WorkerResult;
-      if (result.kind === 'paused') child.kill('SIGKILL');
+      if (result.kind !== 'paused') return;
+      if (sawPause) {
+        failure = new Error('Worker paused more than once');
+        child.kill('SIGKILL');
+        return;
+      }
+      sawPause = true;
+      if (!whilePaused) {
+        child.kill('SIGKILL');
+        return;
+      }
+      void whilePaused().then(() => {
+        if (!failure && child.connected) child.send({ kind: 'resume', now: resumeAt }, error => {
+          if (error) { failure = error; child.kill('SIGKILL'); }
+        });
+      }).catch(error => {
+        failure = error instanceof Error ? error : new Error(String(error));
+        child.kill('SIGKILL');
+      });
     });
-    child.once('exit', code => {
+    // Wait for close, including inherited handles, before a caller removes its
+    // temporary database. In particular a timed-out child must first terminate.
+    child.once('close', (code, signal) => {
       clearTimeout(timer);
-      if (result && (code === 0 || result.kind === 'paused')) resolve(result);
-      else reject(new Error(`Worker failed (${code}): ${stderr}`));
+      if (failure) reject(failure);
+      else if (result && code === 0 && (!whilePaused || sawPause)) resolve(result);
+      else if (result?.kind === 'paused' && !whilePaused && (signal === 'SIGKILL' || code !== 0)) resolve(result);
+      else reject(new Error(`Worker failed (${code}, ${signal}): ${stderr}`));
     });
   });
 }
-export function effectCount(path: string): number {
-  const db = new DatabaseSync(path);
-  try { return Number(db.prepare('SELECT count(*) AS n FROM effects').get()!.n); }
-  finally { db.close(); }
+
+export function runWorker(journal: string, ledger: string, strategy: Strategy | 'claim', phase: FaultPhase | 'none' = 'none', now = 100): Promise<WorkerResult> {
+  return launchWorker(journal, ledger, strategy, phase, now);
 }
+
+/** Keep an old executor alive while the callback runs competing processes. */
+export function resumeWorkerAfter(
+  journal: string, ledger: string, strategy: Strategy, phase: Exclude<FaultPhase, 'response-loss'>,
+  whilePaused: () => Promise<void>, resumeAt: number,
+): Promise<WorkerResult> {
+  return launchWorker(journal, ledger, strategy, phase, 100, whilePaused, resumeAt);
+}
+
+export function ledgerCounts(path: string): LedgerCounts {
+  const db = new DatabaseSync(path);
+  try {
+    return {
+      calls: Number(db.prepare('SELECT count(*) AS n FROM calls').get()!.n),
+      effects: Number(db.prepare('SELECT count(*) AS n FROM effects').get()!.n),
+    };
+  } finally { db.close(); }
+}
+
+export function effectCount(path: string): number { return ledgerCounts(path).effects; }

--- a/tests/fixtures/worker.ts
+++ b/tests/fixtures/worker.ts
@@ -1,50 +1,102 @@
 import { DatabaseSync } from 'node:sqlite';
 import { Journal, SqliteStore, type Json } from '../../src/index.js';
+import { canonical, digest } from '../../src/json.js';
 
 const [journalPath, ledgerPath, strategy, phase, time] = process.argv.slice(2) as [string, string, string, string, string];
-const now = Number(time);
+let now = Number(time);
+
 async function report(value: unknown): Promise<void> {
   await new Promise<void>((resolve, reject) => process.send!(value, undefined, undefined, (error: Error | null) => error ? reject(error) : resolve()));
 }
+
 async function pause(at: string): Promise<void> {
-  if (phase === at) {
-    await report({ kind: 'paused', phase: at });
-    await new Promise(() => setInterval(() => {}, 60_000));
-  }
+  if (phase !== at) return;
+  // The parent either kills us or resumes this same executor after another one runs.
+  await new Promise<void>((resolve, reject) => {
+    function cleanup(): void {
+      process.off('message', resume);
+      process.off('disconnect', disconnected);
+    }
+    function disconnected(): void {
+      cleanup();
+      reject(new Error('Parent disconnected while the executor was paused'));
+    }
+    function resume(message: unknown): void {
+      const command = message as { kind?: string; now?: number };
+      if (command.kind !== 'resume') return;
+      cleanup();
+      if (!Number.isSafeInteger(command.now) || command.now! < now) {
+        reject(new Error('Resume time must be an integer at or after acquisition'));
+        return;
+      }
+      now = command.now!;
+      resolve();
+    }
+    process.on('message', resume);
+    process.once('disconnect', disconnected);
+    void report({ kind: 'paused', phase: at }).catch(error => { cleanup(); reject(error); });
+  });
 }
 
-const store = new SqliteStore(journalPath);
-const ledger = new DatabaseSync(ledgerPath, { timeout: 5_000 });
-ledger.exec('PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; CREATE TABLE IF NOT EXISTS effects (receipt INTEGER PRIMARY KEY, action TEXT, units INTEGER NOT NULL) STRICT; CREATE UNIQUE INDEX IF NOT EXISTS effect_key ON effects(action); CREATE TABLE IF NOT EXISTS checkpoint (result TEXT NOT NULL) STRICT;');
-const journal = new Journal(store, () => now);
+const usesJournal = strategy.startsWith('journal') || strategy === 'claim';
+const store = usesJournal ? new SqliteStore(journalPath) : undefined;
+const journal = store ? new Journal(store, () => now) : undefined;
 const intent = { scope: 'synthetic-ledger', key: 'append-7', tool: 'append', input: { units: 7 }, recovery: strategy === 'journal-manual' ? 'manual' as const : 'idempotent' as const };
+// Identical downstream identity in both deduplicating strategies. Keep this check
+// separate from the journal so the baseline does not acquire or read journal state.
+const downstreamKey = digest(canonical([intent.scope, intent.key]));
+let ledger: DatabaseSync | undefined;
 
 try {
-  const begun = strategy.startsWith('journal') || strategy === 'claim' ? journal.begin(intent, 10) : undefined;
-  if (strategy === 'claim') {
-    await report(begun);
-  } else if (begun && begun.kind !== 'acquired') {
+  const begun = journal?.begin(intent, 10);
+  if (strategy === 'claim' || (begun && begun.kind !== 'acquired')) {
     await report(begun);
   } else {
+    ledger = new DatabaseSync(ledgerPath, { timeout: 5_000 });
+    ledger.exec(`
+      PRAGMA journal_mode=WAL;
+      PRAGMA synchronous=FULL;
+      CREATE TABLE IF NOT EXISTS effects (receipt INTEGER PRIMARY KEY, action TEXT, units INTEGER NOT NULL) STRICT;
+      CREATE UNIQUE INDEX IF NOT EXISTS effect_key ON effects(action);
+      CREATE TABLE IF NOT EXISTS calls (attempt INTEGER PRIMARY KEY, action TEXT, units INTEGER NOT NULL) STRICT;
+      CREATE TABLE IF NOT EXISTS checkpoint (result TEXT NOT NULL) STRICT;
+    `);
     const checkpoint = strategy === 'checkpoint' ? ledger.prepare('SELECT result FROM checkpoint').get() : undefined;
     if (checkpoint) {
       await report({ kind: 'replay', result: JSON.parse(String(checkpoint.result)) });
     } else {
       await pause('before-effect');
-      const action = strategy === 'journal-idempotent' && begun?.kind === 'acquired' ? begun.lease.id : null;
+      const deduplicates = strategy === 'journal-idempotent' || strategy === 'downstream-idempotency-only';
+      if (strategy === 'journal-idempotent' && begun?.kind === 'acquired' && begun.lease.id !== downstreamKey) {
+        throw new Error('Journal and baseline must use the same downstream key');
+      }
+      const action = deduplicates ? downstreamKey : null;
       ledger.exec('BEGIN IMMEDIATE');
       let result: Json;
       try {
-        ledger.prepare('INSERT OR IGNORE INTO effects(action, units) VALUES (?, 7)').run(action);
+        // A call means the synthetic service accepted a request, even when its
+        // idempotency key makes the durable effect a no-op.
+        ledger.prepare('INSERT INTO calls(action, units) VALUES (?, 7)').run(action);
+        ledger.prepare('INSERT INTO effects(action, units) VALUES (?, 7) ON CONFLICT(action) DO NOTHING').run(action);
         const receipt = action === null ? ledger.prepare('SELECT last_insert_rowid() AS receipt').get() : ledger.prepare('SELECT receipt FROM effects WHERE action = ?').get(action);
         result = { receipt: Number(receipt!.receipt), units: 7 };
         ledger.exec('COMMIT');
       } catch (error) { ledger.exec('ROLLBACK'); throw error; }
-      await pause('after-effect');
-      const completed = begun?.kind === 'acquired' ? journal.complete(begun.lease, result) : { kind: 'completed' };
-      if (strategy === 'checkpoint') ledger.prepare('INSERT INTO checkpoint VALUES (?)').run(JSON.stringify(result));
-      await pause('after-complete');
-      await report({ ...completed, result });
+      if (phase === 'response-loss') {
+        // Service commit succeeded, but the client receives no receipt. No
+        // checkpoint or journal completion is permitted on this path.
+        await report({ kind: 'response-lost' });
+      } else {
+        await pause('after-effect');
+        const completed = begun?.kind === 'acquired' ? journal!.complete(begun.lease, result) : { kind: 'completed' };
+        if (strategy === 'checkpoint') ledger.prepare('INSERT INTO checkpoint VALUES (?)').run(JSON.stringify(result));
+        await pause('after-complete');
+        await report({ ...completed, result });
+      }
     }
   }
-} finally { ledger.close(); store.close(); process.disconnect!(); }
+} finally {
+  ledger?.close();
+  store?.close();
+  if (process.connected) process.disconnect!();
+}

--- a/tests/http-recovery.test.ts
+++ b/tests/http-recovery.test.ts
@@ -1,0 +1,246 @@
+import { test, type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, request, type ServerResponse } from 'node:http';
+import { once } from 'node:events';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Journal, SqliteStore, type Intent } from '../src/index.js';
+import { appendWithJournal, requestReceipt, ReceiptUnavailable, MAX_RESPONSE_BYTES } from '../examples/http/client.js';
+import { startSyntheticService, MAX_REQUEST_BYTES, type SyntheticService } from '../examples/http/service.js';
+
+const key = 'a'.repeat(64);
+const intent: Intent = { scope: 'http-test', key: 'append-seven', tool: 'append', input: { units: 7 }, recovery: 'idempotent' };
+
+for (const recovery of ['idempotent', 'manual'] as const) {
+  test(`HTTP ${recovery}: lost receipt survives reopening both independent stores`, async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'journal-http-test-'));
+    const journalPath = join(dir, 'journal.sqlite'), downstreamPath = join(dir, 'downstream.sqlite');
+    let service: SyntheticService | undefined;
+    let store: SqliteStore | undefined;
+    let now = 100;
+    try {
+      service = await startSyntheticService(downstreamPath);
+      store = new SqliteStore(journalPath);
+      let journal = new Journal(store, () => now);
+      const action = { ...intent, recovery };
+      service.dropNextReply(recovery);
+      assert.deepEqual(await appendWithJournal(journal, service.port, action, 10), { kind: 'unconfirmed', reason: 'transport' });
+      const committed = service.snapshot();
+      assert.equal(committed.calls, 1);
+      assert.equal(committed.effects, 1, 'the effect must commit before the socket is destroyed');
+      const receipt = { receipt: committed.receipts[0]!.receipt, units: 7 };
+      assert.equal((await appendWithJournal(journal, service.port, action, 10)).kind, 'busy');
+      assert.equal(service.snapshot().calls, 1);
+
+      store.close();
+      store = undefined;
+      await service.close();
+      service = undefined;
+      service = await startSyntheticService(downstreamPath);
+      store = new SqliteStore(journalPath);
+      journal = new Journal(store, () => now);
+      now = 111;
+      const retried = await appendWithJournal(journal, service.port, action, 10);
+      if (recovery === 'idempotent') assert.deepEqual(retried, { kind: 'completed', result: receipt });
+      else assert.deepEqual(retried, { kind: 'indeterminate' });
+      now = 200;
+      const repeated = await appendWithJournal(journal, service.port, action, 10);
+      if (recovery === 'idempotent') assert.deepEqual(repeated, { kind: 'replay', result: receipt });
+      else assert.deepEqual(repeated, { kind: 'indeterminate' });
+      assert.equal((await appendWithJournal(journal, service.port, { ...action, input: { units: 8 } }, 10)).kind, 'conflict');
+      assert.equal(service.snapshot().calls, recovery === 'idempotent' ? 2 : 1);
+      assert.deepEqual(service.snapshot().receipts, committed.receipts);
+    } finally {
+      store?.close();
+      await service?.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+test('HTTP service binds an idempotency key to its original payload', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-http-key-'));
+  const service = await startSyntheticService(join(dir, 'downstream.sqlite'));
+  try {
+    const receipt = await requestReceipt(service.port, 'idempotent', 7, key);
+    assert.deepEqual(await requestReceipt(service.port, 'idempotent', 7, key), receipt);
+    await assert.rejects(requestReceipt(service.port, 'idempotent', 8, key), error => error instanceof ReceiptUnavailable && error.reason === 'http');
+    assert.deepEqual(service.snapshot(), { calls: 3, effects: 1, receipts: [{ ...receipt, key }] });
+  } finally { await service.close(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('HTTP service rejects malformed, oversized, and unsupported requests before an effect', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-http-input-'));
+  const service = await startSyntheticService(join(dir, 'downstream.sqlite'));
+  try {
+    for (const [path, body, contentType, status] of [
+      ['/manual', '{', 'application/json', 400],
+      ['/manual', '{"units":0}', 'application/json', 400],
+      ['/manual', '{"units":7,"extra":true}', 'application/json', 400],
+      ['/manual', 'x'.repeat(MAX_REQUEST_BYTES + 1), 'application/json', 413],
+      ['/manual', '{"units":7}', 'text/plain', 415],
+      ['/idempotent', '{"units":7}', 'application/json', 400],
+      ['/unknown', '{"units":7}', 'application/json', 404],
+    ] as const) {
+      const response = await fetch(`http://127.0.0.1:${service.port}${path}`, {
+        method: 'POST', body, headers: { 'content-type': contentType }, signal: AbortSignal.timeout(2_000), redirect: 'error',
+      });
+      await response.arrayBuffer();
+      assert.equal(response.status, status);
+    }
+    assert.deepEqual(service.snapshot(), { calls: 0, effects: 0, receipts: [] });
+  } finally { await service.close(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('streamed requests without content-length cannot bypass the service body limit', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-http-stream-'));
+  const service = await startSyntheticService(join(dir, 'downstream.sqlite'));
+  try {
+    const rejected = await new Promise<boolean>((resolve, reject) => {
+      const req = request({ host: '127.0.0.1', port: service.port, method: 'POST', path: '/manual', agent: false,
+        headers: { 'content-type': 'application/json', 'transfer-encoding': 'chunked' } });
+      const timer = setTimeout(() => { req.destroy(); reject(new Error('Stream limit test timed out')); }, 2_000);
+      req.once('error', () => { clearTimeout(timer); resolve(true); });
+      req.once('response', res => { clearTimeout(timer); res.resume(); resolve(res.statusCode === 413); });
+      req.write(' '.repeat(MAX_REQUEST_BYTES));
+      req.end('{"units":7}');
+    });
+    assert.equal(rejected, true);
+    assert.deepEqual(service.snapshot(), { calls: 0, effects: 0, receipts: [] });
+  } finally { await service.close(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('continuous body progress cannot refresh the absolute HTTP body deadline', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-http-trickle-'));
+  const bodyTimeoutMs = 400;
+  const service = await startSyntheticService(join(dir, 'downstream.sqlite'), bodyTimeoutMs);
+  const req = request({ host: '127.0.0.1', port: service.port, method: 'POST', path: '/manual', agent: false,
+    headers: { 'content-type': 'application/json', 'content-length': MAX_REQUEST_BYTES, expect: '100-continue' } });
+  const closed = new Promise<void>(resolve => { req.once('close', resolve); });
+  req.on('error', () => { /* Expiry must close the socket while its body is incomplete. */ });
+  req.setTimeout(2_000, () => req.destroy());
+  let trickle: ReturnType<typeof setInterval> | undefined;
+  let watchdog: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const accepted = once(req, 'continue');
+    req.flushHeaders();
+    await accepted;
+    let chunksSent = 0;
+    trickle = setInterval(() => {
+      req.write(' ', error => { if (!error) chunksSent++; });
+    }, 25);
+    // Without the absolute deadline the trickle defeats the socket idle timer.
+    // Bound this regression below that separate two-second idle deadline.
+    const bounded = new Promise<never>((_, reject) => {
+      watchdog = setTimeout(() => reject(new Error('Body deadline was refreshed by partial progress')), 1_500);
+    });
+    await Promise.race([closed, bounded]);
+    assert.ok(chunksSent >= 3, 'the request must have made repeated progress before termination');
+    assert.deepEqual(service.snapshot(), { calls: 0, effects: 0, receipts: [] });
+  } finally {
+    clearInterval(trickle);
+    clearTimeout(watchdog);
+    req.destroy();
+    await service.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('service body deadlines reject invalid configuration before startup', async () => {
+  for (const invalid of [0, -1, 0.5, NaN, Infinity, 2_001]) {
+    await assert.rejects(startSyntheticService(':memory:', invalid), /Body deadline/);
+  }
+});
+
+test('service shutdown closes an unfinished HTTP request before its database', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-http-close-'));
+  const path = join(dir, 'downstream.sqlite');
+  let service = await startSyntheticService(path);
+  try {
+    const req = request({ host: '127.0.0.1', port: service.port, method: 'POST', path: '/manual', agent: false,
+      headers: { 'content-type': 'application/json', 'content-length': 100, expect: '100-continue' } });
+    const closed = new Promise<void>(resolve => { req.once('close', resolve); });
+    req.on('error', () => { /* Shutdown deliberately aborts this partial request. */ });
+    req.setTimeout(2_000, () => req.destroy());
+    const accepted = once(req, 'continue');
+    req.flushHeaders();
+    await accepted;
+    await service.close();
+    await closed;
+    await service.close(); // Closing is idempotent.
+    service = await startSyntheticService(path);
+    assert.deepEqual(service.snapshot(), { calls: 0, effects: 0, receipts: [] });
+  } finally { await service.close(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+async function replyServer(t: TestContext, reply: (res: ServerResponse) => void): Promise<{ port: number; calls: () => number }> {
+  let calls = 0;
+  const server = createServer((req, res) => { calls++; req.resume(); reply(res); });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => { server.off('error', reject); resolve(); });
+  });
+  t.after(() => new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+    server.closeAllConnections();
+  }));
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  return { port: address.port, calls: () => calls };
+}
+
+for (const [name, body] of [
+  ['invalid JSON', '{'],
+  ['wrong receipt schema', '{"receipt":0,"units":7}'],
+  ['wrong input in receipt', '{"receipt":1,"units":8}'],
+  ['oversized streamed receipt', 'x'.repeat(MAX_RESPONSE_BYTES + 1)],
+] as const) {
+  test(`HTTP client rejects ${name} without an automatic retry`, async t => {
+    const service = await replyServer(t, res => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.write(body); // Force chunked encoding: the reader must enforce its own limit.
+      res.end();
+    });
+    await assert.rejects(requestReceipt(service.port, 'manual', 7), error => error instanceof ReceiptUnavailable && error.reason === 'invalid-response');
+    assert.equal(service.calls(), 1);
+  });
+}
+
+test('HTTP client rejects redirects instead of following them', async t => {
+  const service = await replyServer(t, res => { res.writeHead(302, { location: '/another-endpoint' }); res.end(); });
+  await assert.rejects(requestReceipt(service.port, 'manual', 7), error => error instanceof ReceiptUnavailable && error.reason === 'http');
+  assert.equal(service.calls(), 1);
+});
+
+test('HTTP client has a total request deadline and makes one attempt', async t => {
+  const service = await replyServer(t, () => { /* Deliberately send no headers or body. */ });
+  await assert.rejects(requestReceipt(service.port, 'manual', 7, undefined, 100), error => error instanceof ReceiptUnavailable && error.reason === 'transport');
+  assert.equal(service.calls(), 1);
+});
+
+test('a receipt arriving after lease expiry is returned as stale, never completed', async t => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-http-expired-'));
+  const store = new SqliteStore(join(dir, 'journal.sqlite'));
+  let now = 100;
+  const journal = new Journal(store, () => now);
+  try {
+    const service = await replyServer(t, res => {
+      now = 111;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"receipt":1,"units":7}');
+    });
+    const action: Intent = { ...intent, recovery: 'manual' };
+    assert.deepEqual(await appendWithJournal(journal, service.port, action, 10), { kind: 'stale', result: { receipt: 1, units: 7 } });
+    assert.deepEqual(await appendWithJournal(journal, service.port, action, 10), { kind: 'indeterminate' });
+    assert.equal(service.calls(), 1);
+  } finally { store.close(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('HTTP helper rejects invalid local configuration before connecting', () => {
+  assert.throws(() => requestReceipt(0, 'manual', 7), /port/);
+  assert.throws(() => requestReceipt(80, 'manual', 7, key), /action key/);
+  assert.throws(() => requestReceipt(80, 'idempotent', 7), /action key/);
+  assert.throws(() => requestReceipt(80, 'manual', 1_001), /units/);
+  assert.throws(() => requestReceipt(80, 'manual', 7, undefined, 0), /deadline/);
+});

--- a/tests/integrity.test.ts
+++ b/tests/integrity.test.ts
@@ -1,0 +1,360 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { Journal, MemoryStore, SqliteStore, type Intent } from '../src/index.js';
+import { canonical, MAX_JSON_BYTES } from '../src/json.js';
+import type { Change, Entry } from '../src/record.js';
+
+const intent: Intent = {
+  scope: 'integrity-test', key: 'one-effect', tool: 'append', input: { units: 1 }, recovery: 'manual',
+};
+
+function withDatabase(run: (store: SqliteStore, raw: DatabaseSync) => void): void {
+  const root = realpathSync(tmpdir());
+  const directory = mkdtempSync(join(root, 'journal-integrity-'));
+  const verifiedDirectory = realpathSync(directory);
+  assert.equal(dirname(verifiedDirectory), root);
+  const path = join(verifiedDirectory, 'journal.sqlite');
+  let store: SqliteStore | undefined;
+  let raw: DatabaseSync | undefined;
+  try {
+    store = new SqliteStore(path);
+    raw = new DatabaseSync(path);
+    run(store, raw);
+  } finally {
+    try { raw?.close(); }
+    finally {
+      try { store?.close(); }
+      finally { rmSync(verifiedDirectory, { recursive: true, force: true }); }
+    }
+  }
+}
+
+function storedEntry(raw: DatabaseSync, id: string): Record<string, unknown> {
+  const row = raw.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(id);
+  assert.ok(row);
+  assert.equal(typeof row.entry, 'string');
+  return JSON.parse(row.entry as string) as Record<string, unknown>;
+}
+
+const malformedFields: Record<string, Record<string, unknown>> = {
+  'array recovery that string-coerces to manual': { recovery: ['manual'] },
+  'object recovery': { recovery: { value: 'manual' } },
+  'null recovery': { recovery: null },
+  'array state that string-coerces to pending': { state: ['pending'] },
+  'array fingerprint': { fingerprint: ['a'.repeat(64)] },
+  'unknown field': { unexpected: true },
+  'indeterminate idempotent action': { recovery: 'idempotent', state: 'indeterminate' },
+  'pending action with a receipt': { result: 'null' },
+  'completed action without a receipt': { state: 'completed', result: null },
+  'string epoch': { epoch: '1' },
+  'exhausted numeric precision': { epoch: Number.MAX_SAFE_INTEGER + 1 },
+  'negative deadline': { leaseUntil: -1 },
+  'empty executor': { executor: '' },
+  'oversized executor': { executor: 'x'.repeat(513) },
+  'mismatched identity': { id: '0'.repeat(64) },
+};
+
+for (const [name, patch] of Object.entries(malformedFields)) {
+  test(`SQLite refuses corrupted state before manual reacquisition: ${name}`, () => {
+    withDatabase((store, raw) => {
+      let now = 0;
+      const journal = new Journal(store, () => now);
+      const begun = journal.begin(intent, 10);
+      assert.equal(begun.kind, 'acquired');
+      if (begun.kind !== 'acquired') throw new Error('Expected acquisition');
+      const original = storedEntry(raw, begun.lease.id);
+      const corrupted = JSON.stringify({ ...original, ...patch });
+      raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?').run(corrupted, begun.lease.id);
+      now = 10;
+
+      assert.throws(() => journal.begin(intent, 10), /Corrupt journal entry/);
+      assert.equal(raw.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(begun.lease.id)?.entry, corrupted);
+
+      // A failed read must release its transaction; restoring the row exposes the
+      // original uncertainty, rather than a new execution or a leaked lock.
+      raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?').run(JSON.stringify(original), begun.lease.id);
+      assert.equal(journal.begin(intent, 10).kind, 'indeterminate');
+    });
+  });
+}
+
+const invalidResults: Record<string, string> = {
+  'nonfinite exponent': '1e400',
+  'noncanonical spacing': ' { "receipt": 1 } ',
+  'duplicate object keys': '{"receipt":1,"receipt":2}',
+  'noncanonical key order': '{"z":1,"a":2}',
+  'oversized JSON value': JSON.stringify('a'.repeat(MAX_JSON_BYTES)),
+  'excessive nesting': '['.repeat(65) + 'null' + ']'.repeat(65),
+  'invalid JSON': '{',
+};
+
+for (const [name, result] of Object.entries(invalidResults)) {
+  test(`SQLite refuses corrupted completed result: ${name}`, () => {
+    withDatabase((store, raw) => {
+      const journal = new Journal(store, () => 0);
+      const begun = journal.begin(intent, 10);
+      assert.equal(begun.kind, 'acquired');
+      if (begun.kind !== 'acquired') throw new Error('Expected acquisition');
+      assert.equal(journal.complete(begun.lease, { receipt: 1 }).kind, 'completed');
+      const original = storedEntry(raw, begun.lease.id);
+      raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?')
+        .run(JSON.stringify({ ...original, result }), begun.lease.id);
+
+      assert.throws(() => journal.begin(intent, 10), /Corrupt journal entry/);
+      assert.throws(() => journal.complete(begun.lease, { receipt: 1 }), /Corrupt journal entry/);
+      assert.throws(() => journal.settle(intent, { receipt: 1 }), /Corrupt journal entry/);
+    });
+  });
+}
+
+test('SQLite accepts a maximum-size escaped receipt and rejects an oversized outer record', () => {
+  withDatabase((store, raw) => {
+    const journal = new Journal(store, () => 0);
+    const begun = journal.begin(intent, 10);
+    assert.equal(begun.kind, 'acquired');
+    if (begun.kind !== 'acquired') throw new Error('Expected acquisition');
+    // Backslashes double once in the receipt and again in its enclosing row.
+    const result = '\\'.repeat((MAX_JSON_BYTES - 2) / 2);
+    assert.equal(Buffer.byteLength(canonical(result)), MAX_JSON_BYTES);
+    assert.equal(journal.complete(begun.lease, result).kind, 'completed');
+    assert.deepEqual(journal.begin(intent), { kind: 'replay', result });
+    const original = storedEntry(raw, begun.lease.id);
+    const oversized = ' '.repeat(2 * MAX_JSON_BYTES + 4_097) + JSON.stringify(original);
+    raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?').run(oversized, begun.lease.id);
+    assert.throws(() => journal.begin(intent), /Corrupt journal entry: oversized record/);
+  });
+});
+
+for (const adapter of ['memory', 'sqlite'] as const) {
+  test(`${adapter}: nested transactions cannot commit a claim and the adapter remains usable`, () => {
+    const store = adapter === 'memory' ? new MemoryStore() : new SqliteStore(':memory:');
+    const journal = new Journal(store, () => 0);
+    try {
+      assert.throws(() => store.transact('f'.repeat(64), () => {
+        journal.begin(intent, 10);
+        throw new Error('The nested claim must never return');
+      }), /Nested journal transaction/);
+      const begun = journal.begin(intent, 10);
+      assert.equal(begun.kind, 'acquired');
+      if (begun.kind !== 'acquired') throw new Error('Expected acquisition');
+      assert.equal(begun.retry, false);
+      assert.equal(begun.lease.epoch, 1);
+      assert.equal(journal.complete(begun.lease, { receipt: 1 }).kind, 'completed');
+      assert.deepEqual(journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+    } finally { if (store instanceof SqliteStore) store.close(); }
+  });
+}
+
+for (const operation of ['constructor', 'transaction'] as const) {
+  test(`SQLite ${operation} preserves the commit failure and closes after rollback failure`, t => {
+    const store = operation === 'transaction' ? new SqliteStore(':memory:') : undefined;
+    const primary = new Error('injected commit failure');
+    const rollback = new Error('injected rollback failure');
+    const originalExec = DatabaseSync.prototype.exec;
+    const originalClose = DatabaseSync.prototype.close;
+    let observed: DatabaseSync | undefined;
+    let closes = 0;
+    t.mock.method(DatabaseSync.prototype, 'exec', function (this: DatabaseSync, sql: string): void {
+      observed = this;
+      if (sql === 'COMMIT') throw primary;
+      if (sql === 'ROLLBACK') throw rollback;
+      originalExec.call(this, sql);
+    });
+    t.mock.method(DatabaseSync.prototype, 'close', function (this: DatabaseSync): void {
+      closes++;
+      originalClose.call(this);
+    });
+    try {
+      assert.throws(() => {
+        if (store) new Journal(store, () => 0).begin(intent, 10);
+        else new SqliteStore(':memory:');
+      }, (error: unknown) => {
+        assert.ok(error instanceof AggregateError);
+        assert.equal(error.cause, primary);
+        assert.deepEqual(error.errors, [primary, rollback]);
+        return true;
+      });
+      assert.equal(closes, 1);
+      assert.ok(observed);
+      assert.equal(observed.isOpen, false);
+      t.mock.restoreAll();
+      if (store) {
+        let entered = false;
+        assert.throws(() => store.transact('f'.repeat(64), () => { entered = true; return { value: true }; }));
+        assert.equal(entered, false);
+      }
+    } finally {
+      t.mock.restoreAll();
+      if (observed?.isOpen) originalClose.call(observed);
+      store?.close();
+    }
+  });
+}
+
+test('SQLite rolls back a failed commit and permits the next claim when cleanup succeeds', t => {
+  const store = new SqliteStore(':memory:');
+  const primary = new Error('injected commit failure');
+  const originalExec = DatabaseSync.prototype.exec;
+  let failNextCommit = true;
+  t.mock.method(DatabaseSync.prototype, 'exec', function (this: DatabaseSync, sql: string): void {
+    if (sql === 'COMMIT' && failNextCommit) { failNextCommit = false; throw primary; }
+    originalExec.call(this, sql);
+  });
+  try {
+    const journal = new Journal(store, () => 0);
+    assert.throws(() => journal.begin(intent, 10), error => error === primary);
+    const begun = journal.begin(intent, 10);
+    assert.equal(begun.kind, 'acquired');
+    if (begun.kind !== 'acquired') throw new Error('Expected acquisition');
+    assert.equal(begun.retry, false);
+    assert.equal(begun.lease.epoch, 1);
+  } finally { t.mock.restoreAll(); store.close(); }
+});
+
+test('canonical encoding rejects an exponentially expanding shared DAG within bounded resources', () => {
+  const moduleUrl = new URL('../src/json.js', import.meta.url).href;
+  const script = `
+    import assert from 'node:assert/strict';
+    import { canonical } from ${JSON.stringify(moduleUrl)};
+    let value = 'leaf';
+    for (let depth = 0; depth < 40; depth++) value = [value, value];
+    assert.throws(() => canonical(value), /JSON exceeds 1 MiB/);
+    process.stdout.write('bounded rejection');
+  `;
+  const child = spawnSync(process.execPath, ['--max-old-space-size=128', '--input-type=module', '--eval', script], {
+    timeout: 10_000, encoding: 'utf8', maxBuffer: 64 * 1_024, windowsHide: true,
+  });
+  assert.equal(child.error, undefined, child.error?.message);
+  assert.equal(child.status, 0, child.stderr);
+  assert.equal(child.stdout, 'bounded rejection');
+});
+
+test('canonical encoding rejects proxies and accessors without executing user code', () => {
+  let executed = 0;
+  const trap = (): never => { executed++; throw new Error('must not execute'); };
+  const proxy = new Proxy({}, { ownKeys: trap, getPrototypeOf: trap, getOwnPropertyDescriptor: trap, get: trap });
+  assert.throws(() => canonical(proxy), /Proxy/);
+  const revoked = Proxy.revocable([], {});
+  revoked.revoke();
+  assert.throws(() => canonical(revoked.proxy), /Proxy/);
+  assert.throws(() => canonical({ get value() { return trap(); } }), /accessor/);
+  assert.equal(executed, 0);
+});
+
+test('canonical byte limits count UTF-8 and JSON escapes at the exact boundary', () => {
+  const atLimit = [
+    'a'.repeat(MAX_JSON_BYTES - 2),
+    'é'.repeat((MAX_JSON_BYTES - 2) / 2),
+    '😀'.repeat(Math.floor((MAX_JSON_BYTES - 2) / 4)) + 'ab',
+    '\0'.repeat(Math.floor((MAX_JSON_BYTES - 2) / 6)) + 'ab',
+  ];
+  for (const value of atLimit) {
+    const encoded = canonical(value);
+    assert.equal(Buffer.byteLength(encoded), MAX_JSON_BYTES);
+    assert.equal(JSON.parse(encoded), value);
+    assert.throws(() => canonical(value + 'x'), /JSON exceeds 1 MiB/);
+  }
+});
+
+test('canonical encoding preserves ordinary deterministic JSON and permits shared values', () => {
+  const shared = { z: -0, a: ['😀', '\ud800', null, false, 1.25] };
+  const value = { right: shared, left: shared };
+  const expectedPart = '{"a":["😀","\\ud800",null,false,1.25],"z":0}';
+  assert.equal(canonical(value), `{"left":${expectedPart},"right":${expectedPart}}`);
+  assert.equal(canonical(JSON.parse('{"__proto__":1,"constructor":2}')), '{"__proto__":1,"constructor":2}');
+  const nullPrototype: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  nullPrototype.value = shared;
+  assert.equal(canonical(nullPrototype), canonical({ value: shared }));
+  let nested: unknown = null;
+  for (let depth = 0; depth < 64; depth++) nested = [nested];
+  assert.doesNotThrow(() => canonical(nested));
+  assert.throws(() => canonical([nested]), /depth 64/);
+});
+
+for (const adapter of ['memory', 'sqlite'] as const) {
+  test(`${adapter}: an async callback cannot report success or commit its eventual result`, async () => {
+    const store = adapter === 'memory' ? new MemoryStore() : new SqliteStore(':memory:');
+    const journal = new Journal(store, () => 0);
+    try {
+      const begun = journal.begin(intent, 10);
+      assert.equal(begun.kind, 'acquired');
+      if (begun.kind !== 'acquired') throw new Error('Expected acquisition');
+      let continued = false;
+      const callback = async (entry: Entry | undefined) => {
+        assert.ok(entry);
+        await Promise.resolve();
+        continued = true;
+        return { value: 'saved', next: { ...entry, state: 'completed', result: 'null' } };
+      };
+      // Simulate a JavaScript consumer: TypeScript already rejects this callback.
+      assert.throws(() => store.transact(begun.lease.id, callback as unknown as (entry: Entry | undefined) => Change<string>));
+      await new Promise<void>(resolve => setImmediate(resolve));
+
+      // Rejection cannot cancel arbitrary JavaScript. Only the returned change is
+      // excluded from the transaction, even though the callback keeps running.
+      assert.equal(continued, true);
+      assert.equal(journal.begin(intent, 10).kind, 'busy');
+      assert.equal(journal.complete(begun.lease, { receipt: 1 }).kind, 'completed');
+      assert.deepEqual(journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+    } finally { if (store instanceof SqliteStore) store.close(); }
+  });
+
+  test(`${adapter}: malformed callback results fail closed and an explicit undefined value is valid`, () => {
+    const store = adapter === 'memory' ? new MemoryStore() : new SqliteStore(':memory:');
+    const journal = new Journal(store, () => 0);
+    try {
+      const begun = journal.begin(intent, 10);
+      assert.equal(begun.kind, 'acquired');
+      if (begun.kind !== 'acquired') throw new Error('Expected acquisition');
+      const entry = store.transact(begun.lease.id, current => ({ value: current }));
+      assert.ok(entry);
+      const completed: Entry = { ...entry, state: 'completed', result: 'null' };
+      const malformed: unknown[] = [
+        undefined, null, 0, 'wrong shape', [], {}, Object.create({ value: true }), { next: completed },
+      ];
+      for (const result of malformed) {
+        assert.throws(() => store.transact(begun.lease.id, () => result as Change<unknown>));
+        assert.equal(journal.begin(intent, 10).kind, 'busy');
+      }
+      const value = store.transact(begun.lease.id, () => ({ value: undefined, next: completed }));
+      assert.equal(value, undefined);
+      assert.deepEqual(journal.begin(intent), { kind: 'replay', result: null });
+    } finally { if (store instanceof SqliteStore) store.close(); }
+  });
+
+  test(`${adapter}: rejecting an async callback observes its later rejection`, () => {
+    const moduleUrl = new URL('../src/index.js', import.meta.url).href;
+    const script = `
+      import assert from 'node:assert/strict';
+      import { Journal, MemoryStore, SqliteStore } from ${JSON.stringify(moduleUrl)};
+      const store = ${adapter === 'memory' ? 'new MemoryStore()' : "new SqliteStore(':memory:')"};
+      const journal = new Journal(store, () => 0);
+      const intent = ${JSON.stringify(intent)};
+      const begun = journal.begin(intent, 10);
+      assert.equal(begun.kind, 'acquired');
+      try {
+        assert.throws(() => store.transact(begun.lease.id, async () => {
+          await Promise.resolve();
+          throw new Error('injected asynchronous failure');
+        }));
+        await new Promise(resolve => setImmediate(resolve));
+        assert.equal(journal.begin(intent, 10).kind, 'busy');
+        assert.equal(journal.complete(begun.lease, null).kind, 'completed');
+        process.stdout.write('rejection observed; adapter reusable');
+      } finally { if (store instanceof SqliteStore) store.close(); }
+    `;
+    // There is deliberately no process-level rejection handler: a forgotten
+    // Promise observer must make this process fail under Node's strict policy.
+    const child = spawnSync(process.execPath, ['--unhandled-rejections=strict', '--input-type=module', '--eval', script], {
+      timeout: 10_000, encoding: 'utf8', maxBuffer: 64 * 1_024, windowsHide: true,
+    });
+    assert.equal(child.error, undefined, child.error?.message);
+    assert.equal(child.status, 0, child.stderr);
+    assert.equal(child.stdout, 'rejection observed; adapter reusable');
+  });
+}

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,51 +1,295 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
 import fc from 'fast-check';
-import { Journal, MemoryStore, type Lease, type Intent } from '../src/index.js';
+import { Journal, MemoryStore, SqliteStore, type Intent, type Lease, type Store } from '../src/index.js';
 
-// A small behavioral oracle: one timeline, one slot, no journal internals imported.
-test('seeded operation histories agree with an independent lease model', () => {
-  const seed = 20260907;
-  fc.assert(fc.property(
-    fc.constantFrom('manual' as const, 'idempotent' as const),
-    fc.array(fc.record({ op: fc.constantFrom('begin', 'tick', 'complete', 'old-complete', 'conflict'), dt: fc.integer({ min: 0, max: 12 }) }), { minLength: 1, maxLength: 100 }),
-    (recovery, commands) => {
-      let now = 0;
-      let deadline = 0;
-      let state: 'empty' | 'running' | 'done' | 'unknown' = 'empty';
-      let current: Lease | undefined;
-      const old: Lease[] = [];
-      const journal = new Journal(new MemoryStore(), () => now);
-      const intent: Intent = { scope: 'model', key: 'one', tool: 'write', input: 1, recovery };
-      for (const c of commands) {
-        if (c.op === 'tick') { now += c.dt; continue; }
-        if (c.op === 'conflict') {
-          if (state !== 'empty') assert.equal(journal.begin({ ...intent, input: 2 }).kind, 'conflict');
-          continue;
+// The oracle uses public outcomes and numbered grants. It does not inspect rows,
+// calculate fingerprints, or use the implementation's serialization helpers.
+interface Account {
+  phase: 'running' | 'uncertain' | 'finished';
+  deadline: number;
+  owner: number;
+  grants: number[];
+  receipt: number | undefined;
+}
+interface Model { now: number; nextGrant: number; accounts: Map<number, Account> }
+interface Runtime {
+  journals: Journal[];
+  stores: Store[];
+  leases: Map<number, Lease>;
+  observed: Set<string>;
+  reopen(client: number): void;
+  close(): void;
+}
+
+const identities = [
+  ['tenant', 'one'], ['tenant', 'two'], ['other', 'one'],
+  ['tenant\u0000one', 'two'], ['tenant', 'one\u0000two'],
+] as const;
+function intent(slot: number, reverse = false): Intent {
+  const [scope, key] = identities[slot]!;
+  const request = { units: slot + 1, enabled: true };
+  const input = reverse ? { request, tags: [slot, null] } : { tags: [slot, null], request };
+  return { scope, key, tool: 'append', input, recovery: slot % 2 === 0 ? 'manual' : 'idempotent' };
+}
+function receipt(value: number, reverse = false) {
+  const details = { labels: ['synthetic', value], verified: true };
+  return reverse ? { details, receipt: value } : { receipt: value, details };
+}
+
+type Target = { slot: number; client: number };
+type Action =
+  | ({ op: 'begin'; duration: number; reverse: boolean } & Target)
+  | { op: 'advance'; elapsed: number }
+  | ({ op: 'complete'; holder: 'first' | 'current'; value: number; reverse: boolean } & Target)
+  | ({ op: 'renew'; holder: 'first' | 'current'; duration: number } & Target)
+  | ({ op: 'settle'; value: number; reverse: boolean } & Target)
+  | ({ op: 'conflict'; field: 'input' | 'tool' | 'recovery' } & Target)
+  | ({ op: 'abort' } & Target)
+  | { op: 'reopen'; client: number };
+
+class ContractCommand implements fc.Command<Model, Runtime> {
+  constructor(readonly action: Action) {}
+
+  check(model: Readonly<Model>): boolean {
+    switch (this.action.op) {
+      case 'complete': case 'renew': case 'conflict': case 'abort':
+        return model.accounts.has(this.action.slot);
+      default: return true;
+    }
+  }
+
+  run(model: Model, real: Runtime): void {
+    const action = this.action;
+    real.observed.add(action.op);
+    if (action.op === 'advance') {
+      model.now += action.elapsed;
+    } else if (action.op === 'reopen') {
+      for (const account of model.accounts.values()) real.observed.add(`reopen:${account.phase}`);
+      real.reopen(action.client);
+    } else {
+      const journal = real.journals[action.client]!;
+      const account = model.accounts.get(action.slot);
+      switch (action.op) {
+        case 'begin': {
+          const value = intent(action.slot, action.reverse);
+          const actual = journal.begin(value, action.duration);
+          real.observed.add(`begin:${actual.kind}`);
+          if (account?.phase === 'finished') {
+            assert.deepEqual(actual, { kind: 'replay', result: receipt(account.receipt!) });
+          } else if (account?.phase === 'uncertain') {
+            assert.deepEqual(actual, { kind: 'indeterminate' });
+          } else if (account && model.now < account.deadline) {
+            assert.deepEqual(actual, { kind: 'busy', leaseUntil: account.deadline });
+          } else if (account && value.recovery === 'manual') {
+            assert.deepEqual(actual, { kind: 'indeterminate' });
+            account.phase = 'uncertain';
+          } else {
+            assert.equal(actual.kind, 'acquired');
+            if (actual.kind !== 'acquired') throw new Error('Expected a new grant');
+            assert.equal(actual.retry, account !== undefined);
+            if (actual.retry) real.observed.add('begin:retry');
+            assert.equal(actual.lease.epoch, (account?.grants.length ?? 0) + 1);
+            for (const previous of real.leases.values()) {
+              assert.notEqual(actual.lease.executor, previous.executor);
+            }
+            const grant = model.nextGrant++;
+            real.leases.set(grant, actual.lease);
+            model.accounts.set(action.slot, {
+              phase: 'running', deadline: model.now + action.duration,
+              owner: grant, grants: [...(account?.grants ?? []), grant], receipt: undefined,
+            });
+          }
+          // Callers retain their input objects; later edits cannot rewrite history.
+          if (value.input && typeof value.input === 'object' && !Array.isArray(value.input)) {
+            value.input.request = { units: -1 };
+          }
+          break;
         }
-        if (c.op === 'old-complete') {
-          for (const lease of old) assert.equal(journal.complete(lease, 42).kind, 'stale');
-          continue;
+        case 'complete': {
+          const grant = action.holder === 'current' ? account!.owner : account!.grants[0]!;
+          const owns = grant === account!.owner;
+          const canCommit = owns && account!.phase === 'running' && model.now < account!.deadline;
+          const expected = owns && account!.phase === 'finished'
+            ? account!.receipt === action.value ? 'replayed' : 'conflict'
+            : canCommit ? 'completed' : 'stale';
+          const value = receipt(action.value, action.reverse);
+          assert.equal(journal.complete(real.leases.get(grant)!, value).kind, expected);
+          real.observed.add(`complete:${expected}`);
+          if (!owns) real.observed.add('complete:retired');
+          if (account!.phase === 'running' && model.now === account!.deadline) real.observed.add('complete:at-expiry');
+          if (canCommit) { account!.phase = 'finished'; account!.receipt = action.value; }
+          value.details.labels.push('caller mutation');
+          break;
         }
-        if (c.op === 'complete') {
-          if (!current) continue;
-          const expected: string = state === 'done' ? 'replayed' : state === 'running' && now < deadline ? 'completed' : 'stale';
-          assert.equal(journal.complete(current, 42).kind, expected);
-          if (expected === 'completed') state = 'done';
-          continue;
+        case 'renew': {
+          const grant = action.holder === 'current' ? account!.owner : account!.grants[0]!;
+          const allowed = grant === account!.owner && account!.phase === 'running' && model.now < account!.deadline;
+          assert.equal(journal.renew(real.leases.get(grant)!, action.duration), allowed);
+          real.observed.add(`renew:${allowed}`);
+          if (allowed) real.observed.add(model.now + action.duration < account!.deadline ? 'renew:nonshortening' : 'renew:extended');
+          if (account!.phase === 'running' && model.now === account!.deadline) real.observed.add('renew:at-expiry');
+          if (allowed) account!.deadline = Math.max(account!.deadline, model.now + action.duration);
+          break;
         }
-        let expected: string;
-        if (state === 'done') expected = 'replay';
-        else if (state === 'unknown') expected = 'indeterminate';
-        else if (state === 'running' && now < deadline) expected = 'busy';
-        else if (state === 'running' && recovery === 'manual') { expected = 'indeterminate'; state = 'unknown'; }
-        else { expected = 'acquired'; state = 'running'; deadline = now + 10; }
-        const actual = journal.begin(intent, 10);
-        assert.equal(actual.kind, expected);
-        if (actual.kind === 'acquired') {
-          if (current) old.push(current);
-          current = actual.lease;
+        case 'settle': {
+          const expected = account?.phase === 'finished'
+            ? account.receipt === action.value ? 'replayed' : 'conflict'
+            : account?.phase === 'uncertain' ? 'settled' : 'not_indeterminate';
+          const value = receipt(action.value, action.reverse);
+          assert.equal(journal.settle(intent(action.slot, action.reverse), value), expected);
+          real.observed.add(`settle:${expected}`);
+          if (account?.phase === 'running' && model.now >= account.deadline) real.observed.add('settle:expired-running');
+          if (expected === 'settled') { account!.phase = 'finished'; account!.receipt = action.value; }
+          value.details.labels.push('caller mutation');
+          break;
+        }
+        case 'conflict': {
+          const changed = intent(action.slot);
+          if (action.field === 'input') changed.input = { units: -1 };
+          if (action.field === 'tool') changed.tool = 'different-tool';
+          if (action.field === 'recovery') changed.recovery = changed.recovery === 'manual' ? 'idempotent' : 'manual';
+          assert.deepEqual(journal.begin(changed), { kind: 'conflict' });
+          assert.equal(journal.settle(changed, receipt(0)), 'conflict');
+          break;
+        }
+        case 'abort': {
+          const lease = real.leases.get(account!.owner)!;
+          const failure = new Error('injected transaction abort');
+          assert.throws(() => real.stores[action.client]!.transact(lease.id, entry => {
+            assert.ok(entry);
+            entry.epoch += 1;
+            throw failure;
+          }), error => error === failure);
+          break;
         }
       }
-    }), { seed, numRuns: 1_000 });
-});
+    }
+    this.checkObservableAccounts(model, real);
+  }
+
+  private checkObservableAccounts(model: Model, real: Runtime): void {
+    for (const [slot, account] of model.accounts) {
+      // Observing an expired running action would itself recover it. Leave that
+      // transition to an explicit begin command so shrinking preserves causality.
+      if (account.phase === 'running' && model.now >= account.deadline) continue;
+      for (const journal of real.journals) {
+        const actual = journal.begin(intent(slot, true));
+        if (account.phase === 'finished') {
+          assert.deepEqual(actual, { kind: 'replay', result: receipt(account.receipt!) });
+          if (actual.kind === 'replay' && actual.result && typeof actual.result === 'object' && !Array.isArray(actual.result)) {
+            actual.result.receipt = -1;
+          }
+          assert.deepEqual(journal.begin(intent(slot)), { kind: 'replay', result: receipt(account.receipt!) });
+        } else if (account.phase === 'uncertain') {
+          assert.deepEqual(actual, { kind: 'indeterminate' });
+        } else {
+          assert.deepEqual(actual, { kind: 'busy', leaseUntil: account.deadline });
+        }
+      }
+    }
+  }
+
+  toString(): string { return JSON.stringify(this.action); }
+}
+
+const slot = fc.integer({ min: 0, max: identities.length - 1 });
+const client = fc.integer({ min: 0, max: 1 });
+const duration = fc.integer({ min: 1, max: 12 });
+const value = fc.integer({ min: 0, max: 3 });
+const reverse = fc.boolean();
+const holder = fc.constantFrom('first' as const, 'current' as const);
+const commands = [
+  fc.record({ op: fc.constant('begin' as const), slot, client, duration, reverse }),
+  fc.record({ op: fc.constant('advance' as const), elapsed: fc.integer({ min: 0, max: 16 }) }),
+  fc.record({ op: fc.constant('complete' as const), slot, client, holder, value, reverse }),
+  fc.record({ op: fc.constant('renew' as const), slot, client, holder, duration }),
+  fc.record({ op: fc.constant('settle' as const), slot, client, value, reverse }),
+  fc.record({ op: fc.constant('conflict' as const), slot, client, field: fc.constantFrom('input' as const, 'tool' as const, 'recovery' as const) }),
+  fc.record({ op: fc.constant('abort' as const), slot, client }),
+  fc.record({ op: fc.constant('reopen' as const), client }),
+].map(arbitrary => arbitrary.map(action => new ContractCommand(action)));
+
+function runtime(adapter: 'memory' | 'sqlite', model: Model, observed: Set<string>): Runtime {
+  const directory = adapter === 'sqlite' ? mkdtempSync(join(tmpdir(), 'journal-model-')) : undefined;
+  const memory = new MemoryStore();
+  const open = (): Store => directory ? new SqliteStore(join(directory, 'state.sqlite')) : memory;
+  const stores = [open(), open()];
+  const journals = stores.map(store => new Journal(store, () => model.now));
+  return {
+    journals, stores, leases: new Map(), observed,
+    reopen(client) {
+      const previous = stores[client]!;
+      if (previous instanceof SqliteStore) previous.close();
+      stores[client] = open();
+      journals[client] = new Journal(stores[client]!, () => model.now);
+    },
+    close() {
+      for (const store of stores) if (store instanceof SqliteStore) store.close();
+      if (directory) {
+        const target = resolve(directory);
+        assert.equal(dirname(target), resolve(tmpdir()));
+        assert.ok(basename(target).startsWith('journal-model-'));
+        rmSync(target, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
+for (const adapter of ['memory', 'sqlite'] as const) {
+  test(`${adapter}: shrinkable multi-action histories preserve the execution contract`, () => {
+    const observed = new Set<string>();
+    const boundary: Action[] = [
+      { op: 'begin', slot: 0, client: 0, duration: 4, reverse: false },
+      { op: 'begin', slot: 1, client: 1, duration: 4, reverse: false },
+      { op: 'advance', elapsed: 1 },
+      { op: 'renew', slot: 0, client: 1, holder: 'current', duration: 1 },
+      { op: 'renew', slot: 1, client: 0, holder: 'current', duration: 6 },
+      { op: 'advance', elapsed: 3 },
+      { op: 'renew', slot: 0, client: 0, holder: 'current', duration: 5 },
+      { op: 'complete', slot: 0, client: 1, holder: 'current', value: 1, reverse: false },
+      { op: 'settle', slot: 0, client: 0, value: 1, reverse: false },
+      { op: 'reopen', client: 0 },
+      { op: 'begin', slot: 0, client: 1, duration: 4, reverse: true },
+      { op: 'reopen', client: 1 },
+      { op: 'settle', slot: 0, client: 1, value: 1, reverse: true },
+      { op: 'complete', slot: 0, client: 0, holder: 'current', value: 1, reverse: false },
+      { op: 'settle', slot: 0, client: 0, value: 2, reverse: false },
+      { op: 'advance', elapsed: 3 },
+      { op: 'renew', slot: 1, client: 1, holder: 'current', duration: 5 },
+      { op: 'complete', slot: 1, client: 0, holder: 'current', value: 2, reverse: false },
+      { op: 'begin', slot: 1, client: 0, duration: 4, reverse: true },
+      { op: 'complete', slot: 1, client: 1, holder: 'first', value: 2, reverse: false },
+      { op: 'renew', slot: 1, client: 1, holder: 'first', duration: 5 },
+      { op: 'complete', slot: 1, client: 1, holder: 'current', value: 2, reverse: true },
+      { op: 'reopen', client: 1 },
+    ];
+    const run = (history: Iterable<fc.Command<Model, Runtime>>) => {
+      const model: Model = { now: 0, nextGrant: 0, accounts: new Map() };
+      const real = runtime(adapter, model, observed);
+      try { fc.modelRun(() => ({ model, real }), history); }
+      finally { real.close(); }
+    };
+    // Cover exact deadlines explicitly; random histories explore interleavings.
+    run(boundary.map(action => new ContractCommand(action)));
+    fc.assert(fc.property(fc.commands(commands, { maxCommands: 100, size: 'max' }), history => {
+      run(history);
+    }), {
+      seed: 20260908,
+      numRuns: adapter === 'memory' ? 500 : 40,
+      verbose: true,
+    });
+    // The boundary walk and seeded histories must reach the risky paths. These
+    // are coverage checks, separate from the behavioral oracle above.
+    for (const outcome of [
+      'begin:acquired', 'begin:retry', 'begin:busy', 'begin:replay', 'begin:indeterminate',
+      'complete:completed', 'complete:replayed', 'complete:conflict', 'complete:stale', 'complete:retired',
+      'complete:at-expiry', 'renew:nonshortening', 'renew:extended', 'renew:at-expiry', 'settle:expired-running',
+      'renew:true', 'renew:false', 'settle:settled', 'settle:replayed', 'settle:conflict', 'settle:not_indeterminate',
+      'conflict', 'abort', 'reopen:running', 'reopen:uncertain', 'reopen:finished',
+    ]) assert.ok(observed.has(outcome), `Histories did not exercise ${outcome}`);
+  });
+}

--- a/tests/process.test.ts
+++ b/tests/process.test.ts
@@ -3,34 +3,125 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { runWorker, effectCount } from './fixtures/process.js';
+import { DatabaseSync } from 'node:sqlite';
+import { runWorker, resumeWorkerAfter, ledgerCounts, faultPhases, strategies, type FaultPhase, type Strategy } from './fixtures/process.js';
 import { SqliteStore } from '../src/index.js';
 
-for (const phase of ['before-effect', 'after-effect', 'after-complete']) {
-  test(`idempotent downstream survives SIGKILL at ${phase}`, async () => {
+// Rows describe observable service requests, committed effects, and the caller's
+// recovery decision. Downstream deduplication is tested independently of receipt replay.
+const expected: Record<Strategy, Record<FaultPhase, [calls: number, effects: number, outcome: string]>> = {
+  naive: {
+    'before-effect': [1, 1, 'completed'], 'after-effect': [2, 2, 'completed'],
+    'after-complete': [2, 2, 'completed'], 'response-loss': [2, 2, 'completed'],
+  },
+  checkpoint: {
+    'before-effect': [1, 1, 'completed'], 'after-effect': [2, 2, 'completed'],
+    'after-complete': [1, 1, 'replay'], 'response-loss': [2, 2, 'completed'],
+  },
+  'downstream-idempotency-only': {
+    'before-effect': [1, 1, 'completed'], 'after-effect': [2, 1, 'completed'],
+    'after-complete': [2, 1, 'completed'], 'response-loss': [2, 1, 'completed'],
+  },
+  'journal-idempotent': {
+    'before-effect': [1, 1, 'completed'], 'after-effect': [2, 1, 'completed'],
+    'after-complete': [1, 1, 'replay'], 'response-loss': [2, 1, 'completed'],
+  },
+  'journal-manual': {
+    'before-effect': [0, 0, 'indeterminate'], 'after-effect': [1, 1, 'indeterminate'],
+    'after-complete': [1, 1, 'replay'], 'response-loss': [1, 1, 'indeterminate'],
+  },
+};
+
+for (const strategy of strategies) for (const phase of faultPhases) {
+  test(`${strategy}: restart after ${phase}`, async () => {
     const dir = mkdtempSync(join(tmpdir(), 'journal-crash-'));
     const journal = join(dir, 'journal.sqlite'), ledger = join(dir, 'ledger.sqlite');
     try {
-      const stopped = await runWorker(journal, ledger, 'journal-idempotent', phase);
-      assert.equal(stopped.kind, 'paused');
-      const recovered = await runWorker(journal, ledger, 'journal-idempotent', 'none', 111);
-      assert.ok(['completed', 'replay'].includes(recovered.kind));
-      assert.equal(effectCount(ledger), 1);
-      const replay = await runWorker(journal, ledger, 'journal-idempotent', 'none', 1_000);
-      assert.equal(replay.kind, 'replay');
-      assert.deepEqual(replay.result, recovered.result);
+      const stopped = await runWorker(journal, ledger, strategy, phase);
+      assert.equal(stopped.kind, phase === 'response-loss' ? 'response-lost' : 'paused');
+      assert.equal(stopped.result, undefined, 'failure must not provide a receipt to the caller');
+      const recovered = await runWorker(journal, ledger, strategy, 'none', 111);
+      const [calls, effects, outcome] = expected[strategy][phase];
+      assert.equal(recovered.kind, outcome);
+      assert.deepEqual(ledgerCounts(ledger), { calls, effects });
+      if (strategy.startsWith('journal')) {
+        const restarted = await runWorker(journal, ledger, strategy, 'none', 1_000);
+        assert.equal(restarted.kind, outcome === 'indeterminate' ? 'indeterminate' : 'replay');
+        assert.deepEqual(restarted.result, recovered.result);
+        assert.deepEqual(ledgerCounts(ledger), { calls, effects }, 'restart must not invoke the service after a completed or uncertain action');
+      }
     } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 }
 
-test('manual downstream does not repeat an action after an ambiguous crash', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'journal-manual-'));
+test('both idempotent strategies send the identical stable downstream key', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-identity-'));
+  try {
+    const keys: string[] = [];
+    for (const strategy of ['downstream-idempotency-only', 'journal-idempotent'] as const) {
+      const journal = join(dir, `${strategy}.sqlite`), ledger = join(dir, `${strategy}-ledger.sqlite`);
+      await runWorker(journal, ledger, strategy, 'response-loss');
+      await runWorker(journal, ledger, strategy, 'none', 111);
+      const db = new DatabaseSync(ledger);
+      try {
+        const actions = db.prepare('SELECT action FROM calls ORDER BY attempt').all();
+        assert.equal(actions.length, 2);
+        assert.equal(actions[0]!.action, actions[1]!.action);
+        assert.match(String(actions[0]!.action), /^[a-f0-9]{64}$/);
+        keys.push(String(actions[0]!.action));
+      } finally { db.close(); }
+    }
+    assert.equal(keys[0], keys[1]);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('repeated lost responses keep one effect and eventually recover its receipt', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-lost-response-'));
   const journal = join(dir, 'journal.sqlite'), ledger = join(dir, 'ledger.sqlite');
   try {
-    await runWorker(journal, ledger, 'journal-manual', 'after-effect');
-    const result = await runWorker(journal, ledger, 'journal-manual', 'none', 111);
-    assert.equal(result.kind, 'indeterminate');
-    assert.equal(effectCount(ledger), 1);
+    for (const now of [100, 111, 122]) {
+      assert.equal((await runWorker(journal, ledger, 'journal-idempotent', 'response-loss', now)).kind, 'response-lost');
+    }
+    const result = await runWorker(journal, ledger, 'journal-idempotent', 'none', 133);
+    assert.equal(result.kind, 'completed');
+    assert.deepEqual(result.result, { receipt: 1, units: 7 });
+    assert.deepEqual(ledgerCounts(ledger), { calls: 4, effects: 1 });
+    assert.equal((await runWorker(journal, ledger, 'journal-idempotent', 'none', 200)).kind, 'replay');
+    assert.deepEqual(ledgerCounts(ledger), { calls: 4, effects: 1 });
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+for (const phase of ['before-effect', 'after-effect'] as const) {
+  test(`an old executor resumed at ${phase} cannot overwrite a newer receipt`, async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'journal-old-executor-'));
+    const journal = join(dir, 'journal.sqlite'), ledger = join(dir, 'ledger.sqlite');
+    try {
+      const old = await resumeWorkerAfter(journal, ledger, 'journal-idempotent', phase, async () => {
+        assert.equal((await runWorker(journal, ledger, 'journal-idempotent', 'none', 105)).kind, 'busy');
+        assert.equal((await runWorker(journal, ledger, 'journal-idempotent', 'none', 111)).kind, 'completed');
+      }, 112);
+      assert.equal(old.kind, 'stale');
+      const replay = await runWorker(journal, ledger, 'journal-idempotent', 'none', 200);
+      assert.equal(replay.kind, 'replay');
+      assert.deepEqual(replay.result, { receipt: 1, units: 7 });
+      assert.deepEqual(ledgerCounts(ledger), { calls: 2, effects: 1 });
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+}
+
+test('manual uncertainty does not cancel an already running executor', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-late-manual-'));
+  const journal = join(dir, 'journal.sqlite'), ledger = join(dir, 'ledger.sqlite');
+  try {
+    const old = await resumeWorkerAfter(journal, ledger, 'journal-manual', 'before-effect', async () => {
+      assert.equal((await runWorker(journal, ledger, 'journal-manual', 'none', 111)).kind, 'indeterminate');
+      assert.deepEqual(ledgerCounts(ledger), { calls: 0, effects: 0 });
+    }, 112);
+    assert.equal(old.kind, 'stale');
+    // A journal lease fences the journal, not the service. Quiesce the old
+    // executor before externally verifying a receipt and settling uncertainty.
+    assert.deepEqual(ledgerCounts(ledger), { calls: 1, effects: 1 });
+    assert.equal((await runWorker(journal, ledger, 'journal-manual', 'none', 200)).kind, 'indeterminate');
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
@@ -42,5 +133,19 @@ test('eight OS processes contend for one slot; exactly one acquires it', async (
     const results = await Promise.all(Array.from({ length: 8 }, () => runWorker(journal, ledger, 'claim')));
     assert.equal(results.filter(r => r.kind === 'acquired').length, 1);
     assert.equal(results.filter(r => r.kind === 'busy').length, 7);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('competing callers do not contact the downstream during a live journal lease', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'journal-live-lease-'));
+  const journal = join(dir, 'journal.sqlite'), ledger = join(dir, 'ledger.sqlite');
+  try {
+    const result = await resumeWorkerAfter(journal, ledger, 'journal-idempotent', 'before-effect', async () => {
+      const competitors = await Promise.all(Array.from({ length: 8 }, () => runWorker(journal, ledger, 'journal-idempotent', 'none', 105)));
+      assert.equal(competitors.filter(r => r.kind === 'busy').length, 8);
+      assert.deepEqual(ledgerCounts(ledger), { calls: 0, effects: 0 });
+    }, 106);
+    assert.equal(result.kind, 'completed');
+    assert.deepEqual(ledgerCounts(ledger), { calls: 1, effects: 1 });
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
Malformed persisted recovery policies could pass decoding and authorize a retry of a manual action. Invalid receipts could also be replayed, and memory transactions did not reject nesting like SQLite. This change validates stored records and callback results, bounds JSON during encoding, and preserves primary storage errors when rollback or cleanup fails.

Recovery evidence now includes multi-action memory and SQLite models, stale executors, real HTTP receipt loss, and a downstream-idempotency-only control. The experiment reports calls separately from effects: downstream idempotency prevents duplicates, while the journal coordinates execution and replays recorded receipts. Manual recovery preserves uncertainty.

Validation on Windows / Node 24.15.0: `npm run check` passed 91 tests, seven targeted mutations, the public-tree check, and offline archive installation with a TypeScript consumer and SQLite reopen. HTTP tests include continuous body progress that must still hit an absolute deadline. CI runs the same checks and 100-case experiment on Linux, Windows, and macOS with Node 24.15.0 and 26.

Release version: 0.1.1. Valid 0.1.0 records retain their canonical representation; malformed records now fail closed. The SQLite adapter remains synchronous and local to one host. Synthetic experiments do not establish a production SLA, cross-service exactly-once execution, or independent security certification.
