### PR TITLE
Recover LangGraph tool nodes through a durable operation journal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+  - package-ecosystem: npm
+    directory: /integrations/langgraph
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Journal checks
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 permissions:
   contents: read
 concurrency:
@@ -24,6 +27,12 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm run check
+      - run: npm ci
+        working-directory: integrations/langgraph
+      - run: npm test
+        working-directory: integrations/langgraph
+      - run: npm run demo
+        working-directory: integrations/langgraph
       - run: npm run benchmark
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.2
+
+- Add an independently installed LangGraph integration using the official SQLite
+  checkpointer and the library's packaged public API. Process-kill regressions
+  distinguish graph checkpoints, journal receipts and downstream effects.
+- Check the integration on all supported CI platforms and Node versions while
+  keeping framework dependencies outside the library's runtime manifest.
+- Scan tracked and untracked public candidates, including force-staged ignored
+  files, without traversing installed integration dependencies.
+- Declare the Node ambient type environment explicitly and avoid duplicate
+  branch-push checks when a pull request is already checked.
+
 ## 0.1.1
 
 - Reject malformed persisted recovery policies and noncanonical receipts before

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing
 
+Changes affecting integration behavior also need the independently installed
+[LangGraph example](integrations/langgraph): run its `npm ci`, `npm test` and
+`npm run demo` after installing the root project. The example's native dependencies
+belong to its own lockfile; do not move them into the library's runtime manifest.
+
 Run `npm ci` and `npm run check` on Node.js 24.15+. Include a reproducing sequence
 for changes to lease or recovery behavior. For concurrency bugs, a process test
 with an explicit rendezvous is more useful than a timing-dependent sleep.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ process; HTTP tests reopen stores normally, while the separate process tests
 exercise forced termination. Network deadlines do not include synchronous
 SQLite lock waits.
 
+The [LangGraph integration](integrations/langgraph) uses a real `StateGraph` and
+the official SQLite checkpointer. Its process-kill tests cover a failed HTTP node
+and the gap between journal completion and the next graph checkpoint. The
+framework has its own pinned dependencies; the graph imports the installed
+library archive through the public API. No model key or external service is needed.
+
 ## Use the journal
 
 ```ts
@@ -131,6 +137,8 @@ an assertion failure for each. It is not a whole-project mutation score. The pac
 check installs the real archive offline in a fresh project, exercises SQLite reopen
 through the public exports, and compiles a TypeScript consumer. CI runs on Linux,
 Windows and macOS with the minimum supported Node 24 release and Node 26.
+The same matrix installs and tests the LangGraph example, including its native
+SQLite checkpointer, separately from the dependency-free library.
 
 ## Project scope
 

--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -1,0 +1,131 @@
+# LangGraph: recovering a tool receipt
+
+This example runs a real `StateGraph` against a synthetic loopback HTTP service.
+The graph uses the official `SqliteSaver`; tool-journal keeps a separate durable
+record of each logical tool operation. There is no model call, API key, or trading
+integration.
+
+## Run
+
+Requires Node 24.15 or newer. From the repository root:
+
+```sh
+npm ci
+cd integrations/langgraph
+npm ci
+npm test
+npm run demo
+```
+
+The example has its own dependency manifest and lockfile. Its `prepare` script
+builds the root project, runs `npm pack`, and installs that archive with
+`--no-save --ignore-scripts`. [graph.ts](graph.ts) imports the installed package's
+public export. It does not import the implementation through a relative source
+path. The root library retains zero runtime dependencies.
+
+The local archive intentionally stays outside the framework lockfile; `prepare`
+checks that installing it leaves that lock unchanged. Consequently `npm ls`
+labels tool-journal as **extraneous**. Run `npm run prepare` after changing the
+root library, or after a command that prunes unlisted packages. No archive or
+registry publication is needed in this example's Git history.
+
+`@langchain/langgraph` is pinned to 1.4.14, `@langchain/core` to 1.1.48,
+`@langchain/langgraph-checkpoint-sqlite` to 1.0.4, and its native `better-sqlite3`
+dependency to 12.10.0. The native dependency supports Node 24 and 26 in its
+published engine range. Installation may require a compiler when a matching
+prebuilt binary is unavailable. Do not copy `node_modules` between Node majors.
+
+## The boundary that checkpoints leave open
+
+```text
+prepare node checkpoint
+        |
+journal.begin(scope, key, tool, input)
+        |
+HTTP service commits an effect
+        |
+HTTP receipt reaches the node
+        |
+journal.complete(lease, receipt)
+        |
+append node returns -> LangGraph saves its next checkpoint
+```
+
+Three independent files serve different purposes:
+
+| File | Owns | Does not establish |
+| --- | --- | --- |
+| `graph.sqlite` | LangGraph state, pending nodes, and thread checkpoints | Whether an external service committed its request |
+| `journal.sqlite` | Logical operation identity, lease ownership, uncertainty, and a confirmed receipt | A transaction spanning the HTTP service |
+| `downstream.sqlite` | Synthetic effects and the downstream idempotency contract | Whether the caller received a response |
+
+The `prepare` node validates the action and clears the prior result. Invocations
+use `durability: 'sync'` to persist the graph step before its successor runs. The
+`append` node has `retryPolicy: { maxAttempts: 1 }`. A transport error escapes;
+the caller decides whether and when to resume the failed node using the same
+`thread_id` and `graph.invoke(null, config)`.
+
+The application's `scope` and `key` identify one logical operation. They stay
+constant across graph threads, task IDs, checkpoint IDs, and retry attempts.
+Changing the units or recovery contract under that identity produces `conflict`
+before another HTTP request. A different intended operation needs a different
+application key. The graph thread ID remains LangGraph's state identity, not an
+HTTP idempotency key.
+
+## What the example and tests demonstrate
+
+The service can close its TCP connection immediately **after** its SQLite commit,
+before sending HTTP response headers. In idempotent mode, an explicit retry
+after lease expiry sends the same downstream key and recovers the original
+receipt. In manual mode, resuming after expiry returns `indeterminate` and makes
+no further HTTP request. It never calls `settle` or invents evidence of success.
+
+Expected demo output:
+
+```text
+idempotent: failed node -> completed on resume -> replay in a new graph thread
+            2 HTTP calls, 1 effect
+manual:     failed node -> indeterminate on resume -> still indeterminate
+            1 HTTP call, 1 effect
+```
+
+[recovery.test.ts](tests/recovery.test.ts) also kills actual child processes at
+two boundaries: after a lost response fails the node, and after a receipt is
+committed to the journal but before that node returns to LangGraph. The HTTP
+service stays alive in the parent process. A new graph runtime opens the official
+SQLite checkpoints and resumes the pending node. In the second case, the saved
+graph state still has no outcome; tool-journal supplies the receipt without a
+second HTTP call. Both boundaries are tested for idempotent and manual actions.
+
+A new graph thread deliberately executes the tool node again in the replay test.
+This distinguishes journal replay from LangGraph simply returning an already
+completed graph checkpoint. Other regressions cover changed intent, independent
+graph threads competing for one operation, and manual recovery before and after
+lease expiry.
+
+## Limits
+
+- The demo uses normal close/reopen; the tests additionally use OS process kills.
+  They do not simulate power loss, disk failure, or a remote provider's behavior.
+- `SqliteSaver` is the official local SQLite checkpointer, not a multi-host or
+  highly available checkpoint service. One caller owns an active graph thread;
+  do not concurrently invoke the same thread from different workers.
+- A downstream idempotency key prevents duplicate effects only for the provider's
+  actual retention and payload contract. A graph checkpoint or journal lease
+  cannot cancel an old executor or create cross-service exactly-once execution.
+- The default journal lease is five seconds; the demo and crash tests inject
+  logical time with ten-millisecond leases. A `busy` result does not schedule a
+  retry. If a node returns `busy`, its graph step has finished; inspecting it
+  later requires a new explicit graph invocation with the same logical action.
+- The reused [synthetic HTTP adapter](synthetic-http.mjs) binds only `127.0.0.1`
+  and has bounded request and response sizes and a finite network deadline.
+  SQLite locking is a separate synchronous wait. This example does not offer
+  cancellation or a hard end-to-end request latency bound.
+- Connections close after graph invocations settle. The CLI preload disables
+  inherited LangChain/LangSmith tracing flags for the example process. Normal
+  dependency installation still downloads npm packages and native binaries.
+
+For the framework contracts, see LangChain's
+[checkpointer documentation](https://docs.langchain.com/oss/javascript/langgraph/persistence),
+[fault-tolerance documentation](https://docs.langchain.com/oss/javascript/langgraph/fault-tolerance),
+and the [official SQLite saver implementation](https://github.com/langchain-ai/langgraphjs/tree/main/libs/checkpoint-sqlite).

--- a/integrations/langgraph/demo.ts
+++ b/integrations/langgraph/demo.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startSyntheticService, ReceiptUnavailable } from '#synthetic-http';
+import { openRuntime, threadConfig, type Action } from './graph.js';
+
+const directory = mkdtempSync(join(tmpdir(), 'journal-langgraph-demo-'));
+try {
+  for (const recovery of ['idempotent', 'manual'] as const) {
+    const service = await startSyntheticService(join(directory, `${recovery}-downstream.sqlite`));
+    let runtime: ReturnType<typeof openRuntime> | undefined;
+    try {
+      let now = 100;
+      runtime = openRuntime(directory, service.port, { clock: () => now, leaseMs: 10 });
+      const config = threadConfig(`${recovery}-thread`);
+      const action: Action = { scope: `synthetic-${recovery}`, key: 'append-seven', units: 7, recovery };
+      service.dropNextReply(recovery);
+      await assert.rejects(runtime.graph.invoke({ action }, config), ReceiptUnavailable);
+      assert.equal(service.snapshot().effects, 1);
+      runtime.close();
+      runtime = openRuntime(directory, service.port, { clock: () => now, leaseMs: 10 });
+      now = 111;
+      const recovered = await runtime.graph.invoke(null, config);
+      assert.equal(recovered.outcome?.kind, recovery === 'idempotent' ? 'completed' : 'indeterminate');
+      // A separate graph invocation must execute its node again. This tests the
+      // journal's replay, rather than LangGraph simply returning a saved result.
+      const repeated = await runtime.graph.invoke({ action }, threadConfig(`${recovery}-another-thread`));
+      assert.equal(repeated.outcome?.kind, recovery === 'idempotent' ? 'replay' : 'indeterminate');
+      const ledger = service.snapshot();
+      assert.equal(ledger.calls, recovery === 'idempotent' ? 2 : 1);
+      assert.equal(ledger.effects, 1);
+      console.log(JSON.stringify({ recovery, resumedNode: recovered.outcome?.kind, newThread: repeated.outcome?.kind, calls: ledger.calls, effects: ledger.effects }));
+    } finally {
+      runtime?.close();
+      await service.close();
+    }
+  }
+} finally { rmSync(directory, { recursive: true, force: true }); }

--- a/integrations/langgraph/graph.ts
+++ b/integrations/langgraph/graph.ts
@@ -1,0 +1,85 @@
+import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
+import { SqliteSaver } from '@langchain/langgraph-checkpoint-sqlite';
+import { Journal, SqliteStore, type Begin, type Completion, type Json } from '@raycarllei/tool-journal';
+import { z } from 'zod';
+import { requestReceipt } from '#synthetic-http';
+import { join } from 'node:path';
+
+const ActionSchema = z.object({
+  scope: z.string().min(1).max(512),
+  key: z.string().min(1).max(512),
+  units: z.number().int().min(1).max(1_000),
+  recovery: z.enum(['idempotent', 'manual']),
+}).strict();
+export type Action = z.infer<typeof ActionSchema>;
+export type Outcome = Exclude<Begin, { kind: 'acquired' }> | (Completion & { result: Json });
+
+const State = Annotation.Root({
+  action: Annotation<Action>(),
+  outcome: Annotation<Outcome | null>({ reducer: (_, next) => next, default: () => null }),
+});
+
+export interface RuntimeOptions {
+  clock?: () => number;
+  leaseMs?: number;
+  /** Test injection after journal completion and before the node returns. */
+  afterJournalComplete?: () => Promise<void>;
+}
+
+export function threadConfig(threadId: string) {
+  if (typeof threadId !== 'string' || threadId.length < 1 || threadId.length > 200) throw new TypeError('Invalid graph thread ID');
+  return { configurable: { thread_id: threadId }, durability: 'sync' as const, recursionLimit: 8, callbacks: [] };
+}
+
+/** Three independent stores: graph checkpoints, tool receipts, and HTTP effects. */
+export function openRuntime(directory: string, servicePort: number, options: RuntimeOptions = {}) {
+  if (!Number.isInteger(servicePort) || servicePort < 1 || servicePort > 65_535) throw new TypeError('Expected a loopback port');
+  const leaseMs = options.leaseMs ?? 5_000;
+  if (!Number.isSafeInteger(leaseMs) || leaseMs < 1 || leaseMs > 86_400_000) throw new TypeError('Invalid journal lease duration');
+  const store = new SqliteStore(join(directory, 'journal.sqlite'));
+  let opened: SqliteSaver | undefined;
+  try {
+    opened = SqliteSaver.fromConnString(join(directory, 'graph.sqlite'));
+    opened.db.pragma('synchronous = FULL');
+  } catch (error) {
+    try { opened?.db.close(); } finally { store.close(); }
+    throw error;
+  }
+  const checkpointer = opened;
+  const journal = new Journal(store, options.clock);
+
+  const graph = new StateGraph(State)
+    .addNode('prepare', state => ({ action: ActionSchema.parse(state.action), outcome: null }))
+    .addNode('append', async state => {
+      const action = ActionSchema.parse(state.action);
+      // Logical operation identity comes from the application. LangGraph thread,
+      // checkpoint, task, and retry IDs never become a new downstream action key.
+      const intent = { scope: action.scope, key: action.key, tool: 'synthetic-http-append', input: { units: action.units }, recovery: action.recovery };
+      const begun = journal.begin(intent, leaseMs);
+      if (begun.kind !== 'acquired') return { outcome: begun };
+
+      // A thrown request error leaves the journal pending and the graph node
+      // failed. Resume is an explicit caller decision; this node has one attempt.
+      const receipt = await requestReceipt(servicePort, action.recovery, action.units,
+        action.recovery === 'idempotent' ? begun.lease.id : undefined);
+      const completion = journal.complete(begun.lease, receipt);
+      if (completion.kind === 'completed') await options.afterJournalComplete?.();
+      return { outcome: { ...completion, result: receipt } };
+    }, { retryPolicy: { maxAttempts: 1 } })
+    .addEdge(START, 'prepare')
+    .addEdge('prepare', 'append')
+    .addEdge('append', END)
+    .compile({ checkpointer });
+
+  let closed = false;
+  return {
+    graph,
+    checkpointer,
+    /** Await invocation/stream completion before closing either connection. */
+    close() {
+      if (closed) return;
+      closed = true;
+      try { checkpointer.db.close(); } finally { store.close(); }
+    },
+  };
+}

--- a/integrations/langgraph/package-lock.json
+++ b/integrations/langgraph/package-lock.json
@@ -1,0 +1,787 @@
+{
+  "name": "@raycarllei/tool-journal-langgraph-example",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@raycarllei/tool-journal-langgraph-example",
+      "version": "0.1.0",
+      "dependencies": {
+        "@langchain/core": "1.1.48",
+        "@langchain/langgraph": "1.4.14",
+        "@langchain/langgraph-checkpoint": "1.1.5",
+        "@langchain/langgraph-checkpoint-sqlite": "1.0.4",
+        "zod": "4.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "24.10.1",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=24.15.0"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.1.48",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.48.tgz",
+      "integrity": "sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.14.tgz",
+      "integrity": "sha512-uWAdRYTllfKCnTrlyovExPJCHJwcf3Wl2LzUlnaqsT7Rmoo3aCeYtq/7MV/Pw4q11motG8pR8bjr6T6V8Pe1gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.1.5",
+        "@langchain/langgraph-sdk": "~1.10.2",
+        "@langchain/protocol": "^0.0.19",
+        "@standard-schema/spec": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48",
+        "zod": "^3.25.32 || ^4.2.0"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.5.tgz",
+      "integrity": "sha512-BwDwl5VeTOh6CVuiIPgsUgfK51vTJDMSbFcSCUfjJWsl8/DPdK/mbv+ejxJstkSk/BlSPMP4JfXWcN6jD2ea2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint-sqlite": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint-sqlite/-/langgraph-checkpoint-sqlite-1.0.4.tgz",
+      "integrity": "sha512-tcfDU6mwy9Su7BQKjGLTrWPL2CZzaGwb5XzEttqRRhcI3g4P6a/S7qFoJf6jcP/vP71bere7JRDZPTzahhHqog==",
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^12.10.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.44",
+        "@langchain/langgraph-checkpoint": "^1.1.4"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.10.2.tgz",
+      "integrity": "sha512-86qsfdBZWu1ZgywLN8AThU/jXi9rjPDZPWcTJp4SA1A/L62ypTNoSXbvtiwZt1odokXccYTxK1XWS8tmVdvEmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/protocol": "^0.0.19",
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.19.tgz",
+      "integrity": "sha512-9hKcRrH7cBX6gfutdfXPoft1OCchHe4FEpALoDJMl5Qu+n/YG5ynZmyu8+8cxORlPwHBoKTxggvXz+76M1yX1Q==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.10.2.tgz",
+      "integrity": "sha512-9iqIcEPBMlRT+vvijcjCo4AeHlJHUZjxwbPtDdvQPpGgvo7nYxhsQ7jVd53zXkPstiPfjRhexfnIe0vLltVFmg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.0.tgz",
+      "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/integrations/langgraph/package.json
+++ b/integrations/langgraph/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@raycarllei/tool-journal-langgraph-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "imports": { "#synthetic-http": "./synthetic-http.mjs" },
+  "engines": { "node": ">=24.15.0" },
+  "scripts": {
+    "prepare": "node scripts/install-journal.mjs",
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --import ./scripts/local-only.mjs --test dist/tests/*.test.js",
+    "demo": "npm run build && node --import ./scripts/local-only.mjs dist/demo.js"
+  },
+  "dependencies": {
+    "@langchain/core": "1.1.48",
+    "@langchain/langgraph": "1.4.14",
+    "@langchain/langgraph-checkpoint": "1.1.5",
+    "@langchain/langgraph-checkpoint-sqlite": "1.0.4",
+    "zod": "4.2.0"
+  },
+  "overrides": { "better-sqlite3": "12.10.0" },
+  "devDependencies": { "@types/node": "24.10.1", "typescript": "5.9.3" }
+}

--- a/integrations/langgraph/scripts/install-journal.mjs
+++ b/integrations/langgraph/scripts/install-journal.mjs
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const example = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const root = resolve(example, '../..');
+const npmCli = process.env.npm_execpath;
+if (!npmCli) throw new Error('Run this installer through npm run prepare (or npm ci)');
+const npm = (args, cwd) => execFileSync(process.execPath, [npmCli, ...args], {
+  cwd, encoding: 'utf8', windowsHide: true, timeout: 120_000,
+  stdio: ['ignore', 'pipe', 'inherit'],
+});
+const lock = readFileSync(join(example, 'package-lock.json'));
+const archiveDir = mkdtempSync(join(tmpdir(), 'journal-langgraph-package-'));
+try {
+  process.stdout.write(npm(['run', 'build'], root));
+  const packed = JSON.parse(npm(['pack', '--json', '--ignore-scripts', '--pack-destination', archiveDir], root));
+  const filename = packed[0]?.filename;
+  if (typeof filename !== 'string' || filename !== basename(filename) || !filename.endsWith('.tgz')) throw new Error('Unexpected npm archive filename');
+  // --no-save keeps the framework lock independent of a root archive whose
+  // contents change as this repository evolves. npm still reads that lock.
+  process.stdout.write(npm(['install', '--no-save', '--ignore-scripts', '--no-audit', '--no-fund', join(archiveDir, filename)], example));
+  if (!readFileSync(join(example, 'package-lock.json')).equals(lock)) throw new Error('Installing the root archive unexpectedly changed the framework lock');
+} finally {
+  if (dirname(resolve(archiveDir)) !== resolve(tmpdir()) || !basename(archiveDir).startsWith('journal-langgraph-package-')) {
+    throw new Error('Refusing to clean an unexpected archive directory');
+  }
+  rmSync(archiveDir, { recursive: true, force: true });
+}

--- a/integrations/langgraph/scripts/local-only.mjs
+++ b/integrations/langgraph/scripts/local-only.mjs
@@ -1,0 +1,9 @@
+// This demonstration never needs a model or a tracing service. Override tracing
+// flags for this process before importing the framework, including inherited ones.
+process.env.LANGSMITH_TRACING = 'false';
+process.env.LANGCHAIN_TRACING = '';
+process.env.LANGCHAIN_TRACING_V2 = 'false';
+process.env.LANGSMITH_TRACING_V2 = 'false';
+process.env.LANGSMITH_OTEL_ENABLED = 'false';
+process.env.LANGCHAIN_OTEL_ENABLED = 'false';
+process.env.OTEL_ENABLED = 'false';

--- a/integrations/langgraph/synthetic-http.d.mts
+++ b/integrations/langgraph/synthetic-http.d.mts
@@ -1,0 +1,2 @@
+export { requestReceipt, ReceiptUnavailable, type Receipt } from '../../dist/examples/http/client.js';
+export { startSyntheticService, type SyntheticService } from '../../dist/examples/http/service.js';

--- a/integrations/langgraph/synthetic-http.mjs
+++ b/integrations/langgraph/synthetic-http.mjs
@@ -1,0 +1,4 @@
+// Reuse only the repository's bounded synthetic HTTP service and transport.
+// Graph execution imports tool-journal from the installed npm archive instead.
+export { requestReceipt, ReceiptUnavailable } from '../../dist/examples/http/client.js';
+export { startSyntheticService } from '../../dist/examples/http/service.js';

--- a/integrations/langgraph/tests/recovery.test.ts
+++ b/integrations/langgraph/tests/recovery.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, lstatSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startSyntheticService, ReceiptUnavailable } from '#synthetic-http';
+import { openRuntime, threadConfig, type Action } from '../graph.js';
+
+function crashWorker(directory: string, port: number, recovery: Action['recovery'], fault: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', new URL('../../scripts/local-only.mjs', import.meta.url).href,
+      fileURLToPath(new URL('./worker.js', import.meta.url)), directory, String(port), recovery, fault],
+    { stdio: ['ignore', 'ignore', 'pipe', 'ipc'], windowsHide: true });
+    let paused = false;
+    let failure: Error | undefined;
+    let stderr = '';
+    const deadline = setTimeout(() => { failure = new Error('Graph worker timed out'); child.kill('SIGKILL'); }, 15_000);
+    child.stderr!.on('data', chunk => { stderr = (stderr + String(chunk)).slice(-8_192); });
+    child.once('error', error => { failure = error; });
+    child.on('message', message => {
+      if ((message as { kind: string }).kind === 'paused') { paused = true; child.kill('SIGKILL'); }
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(deadline);
+      if (failure) reject(failure);
+      else if (paused && (signal === 'SIGKILL' || code !== 0)) resolve();
+      else reject(new Error(`Graph worker exited before the injected crash (${code}, ${signal}): ${stderr}`));
+    });
+  });
+}
+
+test('the graph resolves the packaged public export, not a source directory or symlink', () => {
+  const entry = fileURLToPath(import.meta.resolve('@raycarllei/tool-journal'));
+  assert.match(entry.replaceAll('\\', '/'), /\/integrations\/langgraph\/node_modules\/@raycarllei\/tool-journal\/dist\/src\/index\.js$/);
+  assert.equal(lstatSync(new URL('../../node_modules/@raycarllei/tool-journal', import.meta.url)).isSymbolicLink(), false);
+});
+
+for (const recovery of ['idempotent', 'manual'] as const) {
+  test(`LangGraph ${recovery}: resume failed node from official SQLite checkpoints after SIGKILL`, async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'journal-langgraph-failed-'));
+    const service = await startSyntheticService(join(directory, 'downstream.sqlite'));
+    let runtime: ReturnType<typeof openRuntime> | undefined;
+    try {
+      service.dropNextReply(recovery);
+      await crashWorker(directory, service.port, recovery, 'lost-response');
+      const original = service.snapshot();
+      assert.equal(original.calls, 1);
+      assert.equal(original.effects, 1);
+      const config = threadConfig('interrupted-thread');
+      runtime = openRuntime(directory, service.port, { clock: () => 111, leaseMs: 10 });
+      const checkpoint = await runtime.checkpointer.getTuple(config);
+      assert.ok(checkpoint, 'official saver must recover a persisted checkpoint');
+      const suspended = await runtime.graph.getState(config);
+      assert.deepEqual(suspended.next, ['append']);
+      assert.equal(suspended.values.outcome, null);
+
+      const resumed = await runtime.graph.invoke(null, config);
+      assert.equal(resumed.outcome?.kind, recovery === 'idempotent' ? 'completed' : 'indeterminate');
+      const action: Action = { scope: 'process-test', key: 'append-seven', units: 7, recovery };
+      const again = await runtime.graph.invoke({ action }, threadConfig('another-thread'));
+      assert.equal(again.outcome?.kind, recovery === 'idempotent' ? 'replay' : 'indeterminate');
+      for (const changed of [{ ...action, units: 8 }, { ...action, recovery: recovery === 'manual' ? 'idempotent' as const : 'manual' as const }]) {
+        const conflict = await runtime.graph.invoke({ action: changed }, threadConfig('changed-intent'));
+        assert.deepEqual(conflict.outcome, { kind: 'conflict' });
+      }
+      assert.equal(service.snapshot().calls, recovery === 'idempotent' ? 2 : 1);
+      assert.deepEqual(service.snapshot().receipts, original.receipts);
+    } finally { runtime?.close(); await service.close(); rmSync(directory, { recursive: true, force: true }); }
+  });
+
+  test(`LangGraph ${recovery}: SIGKILL between journal completion and node checkpoint replays without HTTP`, async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'journal-langgraph-gap-'));
+    const service = await startSyntheticService(join(directory, 'downstream.sqlite'));
+    let runtime: ReturnType<typeof openRuntime> | undefined;
+    try {
+      await crashWorker(directory, service.port, recovery, 'after-journal-complete');
+      const original = service.snapshot();
+      assert.equal(original.calls, 1);
+      const config = threadConfig('interrupted-thread');
+      runtime = openRuntime(directory, service.port, { clock: () => 111, leaseMs: 10 });
+      const checkpoint = await runtime.graph.getState(config);
+      assert.deepEqual(checkpoint.next, ['append']);
+      assert.equal(checkpoint.values.outcome, null, 'LangGraph must not already have the completed tool result');
+      const resumed = await runtime.graph.invoke(null, config);
+      assert.deepEqual(resumed.outcome, { kind: 'replay', result: { receipt: original.receipts[0]!.receipt, units: 7 } });
+      assert.deepEqual(service.snapshot(), original);
+    } finally { runtime?.close(); await service.close(); rmSync(directory, { recursive: true, force: true }); }
+  });
+}
+
+test('separate graph threads coordinate one logical operation through the journal', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'journal-langgraph-concurrent-'));
+  const service = await startSyntheticService(join(directory, 'downstream.sqlite'));
+  const runtime = openRuntime(directory, service.port, { clock: () => 100, leaseMs: 10 });
+  try {
+    const action: Action = { scope: 'concurrent-test', key: 'append-seven', units: 7, recovery: 'idempotent' };
+    const results = await Promise.all(['a', 'b', 'c'].map(thread => runtime.graph.invoke({ action }, threadConfig(thread))));
+    assert.equal(results.filter(result => result.outcome?.kind === 'completed').length, 1);
+    assert.ok(results.every(result => ['completed', 'busy', 'replay'].includes(result.outcome!.kind)));
+    assert.equal(service.snapshot().calls, 1);
+    assert.equal(service.snapshot().effects, 1);
+  } finally { runtime.close(); await service.close(); rmSync(directory, { recursive: true, force: true }); }
+});
+
+test('manual failure has no graph retry and resumes to uncertainty after its lease expires', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'journal-langgraph-manual-'));
+  const service = await startSyntheticService(join(directory, 'downstream.sqlite'));
+  let now = 100;
+  const runtime = openRuntime(directory, service.port, { clock: () => now, leaseMs: 10 });
+  try {
+    const action: Action = { scope: 'manual-test', key: 'append-seven', units: 7, recovery: 'manual' };
+    const config = threadConfig('manual-thread');
+    service.dropNextReply('manual');
+    await assert.rejects(runtime.graph.invoke({ action }, config), ReceiptUnavailable);
+    assert.equal(service.snapshot().calls, 1);
+    assert.deepEqual((await runtime.graph.invoke(null, config)).outcome, { kind: 'busy', leaseUntil: 110 });
+    now = 111;
+    // The busy result completed that node; a new graph turn explicitly asks to
+    // inspect the same operation again. It cannot authorize another side effect.
+    assert.deepEqual((await runtime.graph.invoke({ action }, config)).outcome, { kind: 'indeterminate' });
+    assert.equal(service.snapshot().calls, 1);
+  } finally { runtime.close(); await service.close(); rmSync(directory, { recursive: true, force: true }); }
+});

--- a/integrations/langgraph/tests/worker.ts
+++ b/integrations/langgraph/tests/worker.ts
@@ -1,0 +1,27 @@
+import { openRuntime, threadConfig, type Action } from '../graph.js';
+import { ReceiptUnavailable } from '#synthetic-http';
+
+const [directory, port, recovery, fault] = process.argv.slice(2) as [string, string, Action['recovery'], string];
+const action: Action = { scope: 'process-test', key: 'append-seven', units: 7, recovery };
+async function pause(): Promise<never> {
+  await new Promise<void>((resolve, reject) => process.send!({ kind: 'paused' }, undefined, undefined,
+    (error: Error | null) => error ? reject(error) : resolve()));
+  return new Promise<never>(() => { setInterval(() => {}, 60_000); });
+}
+
+const runtime = openRuntime(directory, Number(port), {
+  clock: () => 100, leaseMs: 10,
+  ...(fault === 'after-journal-complete' ? { afterJournalComplete: pause } : {}),
+});
+try {
+  try {
+    await runtime.graph.invoke({ action }, threadConfig('interrupted-thread'));
+    throw new Error('Expected the injected fault');
+  } catch (error) {
+    if (fault !== 'lost-response' || !(error instanceof ReceiptUnavailable)) throw error;
+    await pause();
+  }
+} finally {
+  runtime.close();
+  if (process.connected) process.disconnect!();
+}

--- a/integrations/langgraph/tsconfig.json
+++ b/integrations/langgraph/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2023", "module": "NodeNext", "moduleResolution": "NodeNext",
+    "strict": true, "noUncheckedIndexedAccess": true, "exactOptionalPropertyTypes": true,
+    "outDir": "dist", "rootDir": ".", "skipLibCheck": true,
+    "noUnusedLocals": true, "noUnusedParameters": true
+  },
+  "include": ["*.ts", "tests/**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycarllei/tool-journal",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "24.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Durable tool execution with lease fencing, explicit uncertainty, and reproducible crash tests.",
   "license": "MIT",
   "type": "module",

--- a/scripts/check-public.mjs
+++ b/scripts/check-public.mjs
@@ -1,23 +1,34 @@
-import { readdirSync, readFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { lstatSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { basename, join } from 'node:path';
 
-const allowedRoots = new Set(['src', 'tests', 'scripts', 'examples', 'benchmarks', 'docs', '.github']);
+const allowedRoots = new Set(['src', 'tests', 'scripts', 'examples', 'integrations', 'benchmarks', 'docs', '.github']);
 const allowedFiles = new Set(['README.md', 'LICENSE', 'CONTRIBUTING.md', 'SECURITY.md', 'CHANGELOG.md', 'package.json', 'package-lock.json', 'tsconfig.json', '.gitignore', '.gitattributes']);
-const ignored = new Set(['node_modules', '.git', 'dist', 'artifacts']);
+const generated = new Set(['node_modules', '.git', 'dist', 'artifacts', 'coverage']);
 const errors = [];
-function walk(dir) {
-  for (const item of readdirSync(dir, { withFileTypes: true })) {
-    const path = join(dir, item.name), name = relative('.', path).replaceAll('\\', '/');
-    if (dir === '.' && ignored.has(item.name)) continue;
-    if (item.isSymbolicLink()) { errors.push(`${name}: symlink`); continue; }
-    if (dir === '.' && !(item.isDirectory() ? allowedRoots : allowedFiles).has(item.name)) errors.push(`${name}: outside public allowlist`);
-    if (item.isDirectory()) { walk(path); continue; }
-    if (/\.(?:sqlite|db|pem|key|p12|pfx|env|log)(?:$|\.)/i.test(item.name)) errors.push(`${name}: private file type`);
-    const text = readFileSync(path, 'utf8');
-    if (/(?:[A-Z]:[\\/]Users[\\/]|\/Users\/|\/home\/)[^\s"']+/i.test(text)) errors.push(`${name}: local home path`);
-    if (/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|gh[pousr]_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{30,}|sk-[A-Za-z0-9]{30,}/.test(text)) errors.push(`${name}: possible credential`);
+// Inspect publishable candidates, including already tracked files even when
+// ignored. Nested integration dependencies are not source-tree candidates.
+const candidates = new Set(execFileSync('git', ['ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+  { encoding: 'utf8', windowsHide: true }).split('\0').filter(Boolean));
+for (const name of candidates) {
+  const parts = name.split('/');
+  if (!(parts.length === 1 ? allowedFiles : allowedRoots).has(parts[0])) errors.push(`${name}: outside public allowlist`);
+  if (parts.some(part => generated.has(part))) errors.push(`${name}: generated file in public candidates`);
+  // Do not follow symlinked files or parent directories.
+  let path = '.';
+  let readable = true;
+  for (const part of parts) {
+    path = join(path, part);
+    const stat = lstatSync(path, { throwIfNoEntry: false });
+    if (!stat) { readable = false; break; }
+    if (stat.isSymbolicLink()) { errors.push(`${name}: symlink`); readable = false; break; }
   }
+  if (!readable) continue;
+  const file = basename(name);
+  if (/\.(?:sqlite|db|pem|key|p12|pfx|env|log)(?:$|\.)/i.test(file) || file.startsWith('.env')) errors.push(`${name}: private file type`);
+  const text = readFileSync(path, 'utf8');
+  if (/(?:[A-Z]:[\\/]Users[\\/]|\/Users\/|\/home\/)[^\s"']+/i.test(text)) errors.push(`${name}: local home path`);
+  if (/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|gh[pousr]_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{30,}|sk-[A-Za-z0-9]{30,}/.test(text)) errors.push(`${name}: possible credential`);
 }
-walk('.');
 if (errors.length) { console.error(errors.join('\n')); process.exitCode = 1; }
 else console.log('Public allowlist and credential/path checks passed. This is not a complete secret scanner.');

--- a/tests/public-tree.test.ts
+++ b/tests/public-tree.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const checker = fileURLToPath(new URL('../../scripts/check-public.mjs', import.meta.url));
+
+test('public candidates exclude nested installs but include tracked ignored files', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'journal-public-tree-'));
+  function write(name: string, text: string): void {
+    const path = join(directory, name);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, text);
+  }
+  function git(...args: string[]): void {
+    execFileSync('git', args, { cwd: directory, windowsHide: true, stdio: 'ignore' });
+  }
+  function check() {
+    return spawnSync(process.execPath, [checker], {
+      cwd: directory, encoding: 'utf8', windowsHide: true, timeout: 10_000,
+    });
+  }
+  try {
+    git('init', '--quiet');
+    write('.gitignore', 'node_modules/\nartifacts/\n.env*\n');
+    write('integrations/example/demo.mjs', 'export const example = true;\n');
+    write('integrations/example/node_modules/dependency/.env', 'synthetic ignored fixture');
+    write('artifacts/report.json', '{}');
+    const baseline = check();
+    assert.equal(baseline.status, 0, baseline.stderr);
+
+    // Force-staging a generated file cannot hide it behind .gitignore.
+    git('add', '--force', 'integrations/example/node_modules/dependency/.env');
+    const tracked = check();
+    assert.equal(tracked.status, 1);
+    assert.match(tracked.stderr, /generated file in public candidates/);
+    assert.match(tracked.stderr, /private file type/);
+  } finally { rmSync(directory, { recursive: true, force: true }); }
+});
+
+test('public check rejects an untracked private candidate without printing its contents', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'journal-public-tree-'));
+  try {
+    execFileSync('git', ['init', '--quiet'], { cwd: directory, windowsHide: true, stdio: 'ignore' });
+    mkdirSync(join(directory, 'src'));
+    writeFileSync(join(directory, 'src', '.env.local'), 'SYNTHETIC_VALUE=do-not-print-this-fixture');
+    const result = spawnSync(process.execPath, [checker], {
+      cwd: directory, encoding: 'utf8', windowsHide: true, timeout: 10_000,
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /private file type/);
+    assert.doesNotMatch(result.stderr + result.stdout, /do-not-print-this-fixture/);
+  } finally { rmSync(directory, { recursive: true, force: true }); }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2023", "module": "NodeNext", "moduleResolution": "NodeNext",
+    "types": ["node"],
     "strict": true, "noUncheckedIndexedAccess": true, "exactOptionalPropertyTypes": true,
     "declaration": true, "outDir": "dist", "rootDir": ".",
     "skipLibCheck": true, "noUnusedLocals": true, "noUnusedParameters": true


### PR DESCRIPTION
LangGraph can persist a pending tool node after the external service has committed an effect, or before the graph records a receipt already saved by tool-journal. This adds a runnable integration using the real StateGraph and official SQLite checkpointer to reproduce both boundaries through the packaged public API.

The example gives each logical operation a stable identity across graph threads. It recovers a lost receipt through downstream idempotency, replays a confirmed journal receipt without another HTTP call, and leaves an uncertain manual operation for reconciliation. Seven integration tests include actual child-process kills at two boundaries for both recovery policies. Documentation separates graph checkpoints, journal state, and provider guarantees; it makes no cross-service exactly-once or multi-host availability claim.

Framework dependencies and their lockfile stay in the example; the core retains zero runtime dependencies. CI runs the integration on the existing six OS/Node combinations. The public-tree check now uses Git's candidate-file list, checks tracked ignored files and symlinks, and has regressions for nested dependencies and private files. Dependabot monitors the integration separately.

Validation: local Node 24.15.0 core check passed 93 tests, seven targeted mutation checks, and a real package-consumer check. The LangGraph integration passed all seven tests and its demo against the 0.1.2 package; production dependency audit and redacted Git-history scan reported no findings. Cross-platform CI remains the merge gate. Version 0.1.2 is prepared for the corresponding source release.
