### PR TITLE
Bound retry admission and migrate v1 journals without inventing retention

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,19 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    # Major tooling/runtime baselines receive explicit compatibility review.
+    # allow.update-types does not suppress security updates.
+    allow:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-minor', 'version-update:semver-patch']
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
   - package-ecosystem: npm
     directory: /integrations/langgraph
+    allow:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-minor', 'version-update:semver-patch']
     schedule:
       interval: weekly
     open-pull-requests-limit: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.2.0
+
+- Require an explicit finite retry admission window for idempotent operations.
+  Persist its first-acquisition anchor; retries, renewal and reopening cannot reset
+  the cutoff. Expired ownership after admission closes becomes indeterminate.
+- Keep receipt completion and lease renewal independent of retry admission, and
+  preserve completed receipt replay after the cutoff.
+- Migrate v1 SQLite records atomically without inventing historical timestamps.
+  Unknown legacy windows cannot authorize a new retry. Reject old-client writes.
+- Document the API/storage migration and test delayed provider arrival as a limit
+  of client-side authorization, not an exactly-once guarantee.
+
 ## 0.1.2
 
 - Add an independently installed LangGraph integration using the official SQLite

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ TypeScript, SQLite, no runtime dependencies. Requires Node.js 24.15 or later.
 The hard case is a tool that **finishes its external action but loses the response**.
 A checkpoint cannot tell you whether that action happened. This library records
 intent before execution, coordinates leases, and makes uncertainty an explicit
-result. Automatic recovery requires a downstream idempotency contract.
+result. Automatic recovery requires a downstream idempotency contract and an
+explicit, finite retry admission window.
 
 ## Try the failure
 
@@ -26,7 +27,7 @@ ledger, then starts another process to recover. It compares five approaches:
 | Retry without a journal | Repeats the effect |
 | Completion checkpoint | Repeats the effect |
 | Downstream idempotency alone | Retrieves the original receipt through another call |
-| Journal + downstream idempotency | Retrieves the original receipt |
+| Journal + downstream idempotency | Retrieves the original receipt while retry admission remains open |
 | Journal + manual recovery | Stops with `indeterminate` |
 
 Downstream idempotency prevents duplicate effects in both idempotent strategies.
@@ -71,6 +72,7 @@ const intent = {
   tool: 'append',
   input: { units: 7 },
   recovery: 'idempotent' as const,
+  retryForMs: 60_000, // fixed from first acquisition; choose for your downstream contract
 };
 
 const begun = journal.begin(intent, 30_000);
@@ -92,27 +94,38 @@ store.close();
 ```
 
 The API example illustrates an integration; `downstream` is not supplied by this
-package. The clone-and-run demo above is self-contained. v0.1 is distributed as
+package. The clone-and-run demo above is self-contained. v0.2 is distributed as
 source and a release archive; no npm registry publication is assumed.
 
 `begin` binds a scope/key to the tool, canonical input and recovery policy.
-Changing any of those under the same key is a conflict. `complete` fences stale
+Changing any of those or a known retry window under the same key is a conflict. `complete` fences stale
 executors; repeating the same completion is harmless. `renew` extends an active
 lease. `settle` records an independently verified receipt for an indeterminate
 action, **after the caller has stopped old executors**.
+
+For idempotent operations, `retryForMs` is required. The first acquisition fixes
+`retryStartBefore`; retries, renewals and restarts cannot extend it. Once admission
+has closed, an expired pending operation becomes `indeterminate`. An active lease
+can still record its receipt, and a completed receipt remains replayable. Manual
+operations have no retry window. See [retry admission and migration](docs/retry-admission.md).
+
+The cutoff governs journal authorization, not arrival at the downstream service.
+An executor paused before sending, or a delayed request, can still arrive after a
+provider deletes its key. Client timeouts do not establish server-side cancellation.
 
 ## Guarantees and limits
 
 - SQLite transactions serialize claims from processes sharing one local database.
 - Completed results are replayed without another tool invocation by a cooperating caller.
 - An expired manual-recovery action cannot be automatically acquired again.
+- An idempotent action cannot be reacquired at or after its fixed admission cutoff.
 - Lease generations fence journal writes. They do **not** fence an external service.
 - A caller can violate the protocol by executing without a lease, reusing a key
   for another logical action, or falsely declaring the downstream idempotent.
 - No cross-service exactly-once guarantee. No database GC, distributed clock,
   scheduler, authentication, model SDK or live trading integration.
 - Node's built-in SQLite API is experimental in Node 24; the adapter is synchronous.
-  This is a v0.1 reference implementation, not a production SLA.
+  This is a v0.2 reference implementation, not a production SLA.
 
 Read the [failure contract](docs/contract.md) before integrating.
 
@@ -132,7 +145,7 @@ npm run benchmark       # 100 controlled cases; writes artifacts/crash-matrix.js
 npm pack               # compiled library + docs; no fixtures or local databases
 ```
 
-The targeted mutation check removes seven safeguards, one at a time, and requires
+The targeted mutation check removes eight safeguards, one at a time, and requires
 an assertion failure for each. It is not a whole-project mutation score. The package
 check installs the real archive offline in a fresh project, exercises SQLite reopen
 through the public exports, and compiles a TypeScript consumer. CI runs on Linux,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,5 +18,10 @@ For a suspected vulnerability, use this repository's GitHub private vulnerabilit
 reporting feature when enabled. Do not post credentials, private databases or user
 traces in a public issue. Include a minimal synthetic reproduction.
 
-Only the latest 0.1.x release is maintained at this stage. No security audit or
+An admission cutoff limits new journal leases, not the provider's execution time.
+Old executors, delayed requests, a reused pre-journal key and an unstable clock can
+violate an integrator's retention assumptions. See [retry admission](docs/retry-admission.md).
+
+Only the latest 0.2.x release is maintained at this stage. The database upgrade is
+forward-only; stop old executors and back up before migration. No security audit or
 production certification is claimed.

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -29,7 +29,7 @@ const output = {
   protocol: 2, createdAt: new Date().toISOString(), commit, workingTreeDirty,
   environment: { node: process.version, platform: platform(), arch: arch(), osRelease: release() },
   lockSha256: createHash('sha256').update(readFileSync('package-lock.json')).digest('hex'),
-  clock: 'Injected logical milliseconds; acquire=100, recover=111, lease=10. The three pause phases kill real processes; response-loss exits without delivering a committed receipt.',
+  clock: 'Injected logical milliseconds; acquire=100, recover=111, lease=10, idempotent retry admission=1000 from first acquisition. The three pause phases kill real processes; response-loss exits without delivering a committed receipt.',
   downstream: 'Both idempotent strategies use the identical stable action key and a durable deduplicating synthetic service. Calls count accepted requests, including deduplicated requests; effects count service commits.',
   repetitions: 5, scenarios: rows.length, rows,
 };

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -5,7 +5,8 @@
 The caller assigns `(scope, key)` to one logical action. Its SHA-256 digest is the
 downstream idempotency key. The tool name, canonical JSON input and recovery mode
 are a separate fingerprint. A stable logical key with changed input is a conflict,
-not a new action. The scope is a namespace, not an authorization mechanism.
+not a new action. A known `retryForMs` is bound separately and cannot be changed
+under that identity. The scope is a namespace, not an authorization mechanism.
 
 | Stored state | Condition | `begin` result | Change |
 |---|---|---|---|
@@ -13,7 +14,8 @@ not a new action. The scope is a namespace, not an authorization mechanism.
 | any | fingerprint mismatch | conflict | none |
 | completed | fingerprint matches | replay | none |
 | pending | lease has not expired | busy | none |
-| pending | expired, downstream idempotent | acquired | next epoch |
+| pending | expired, downstream idempotent, before known admission cutoff | acquired | next epoch |
+| pending | expired, admission closed or historical window unknown | indeterminate | indeterminate |
 | pending | expired, manual recovery | indeterminate | indeterminate |
 | indeterminate | fingerprint matches | indeterminate | none |
 
@@ -21,6 +23,14 @@ Only a matching epoch and executor can complete a pending record, and only befor
 its deadline. A duplicate completion with the same canonical result is replayed;
 a different result is a conflict. Settlement requires an indeterminate record and
 matching intent. No transition deletes an entry or reuses its key.
+
+The first acquisition fixes `firstAcquiredAt` and `retryStartBefore` in the same
+transaction. For idempotent operations, the latter is the former plus the required
+positive safe-integer `retryForMs`. Overflow is rejected. Manual operations have
+no retry window. A policy change conflicts even when the operation is completed.
+Legacy v1 receipts have no known window; see the migration rules below.
+For a known first acquisition, the lease deadline must be strictly later than
+that timestamp; a persisted record violating this ordering is corrupt.
 
 ## Where uncertainty begins
 
@@ -32,9 +42,20 @@ Availability is sacrificed rather than guessing that retry is safe.
 
 Idempotent recovery is a promise made by the integrator: the downstream atomically
 deduplicates concurrent requests, rejects changed parameters for an existing key,
-and retains both the key and receipt for the full retry horizon. A cache with a
-short TTL does not satisfy an indefinitely retained journal. The synthetic ledger
+and retains both the key and receipt through every possible arrival of a retry.
+Choose the admission window conservatively for that contract. Its first-acquisition
+anchor assumes the downstream key was never used before this journal operation.
+The journal cannot verify provider retention or bound network/queueing delay after
+authorization. In particular, an old executor can send after the provider deletes
+the key. A transport timeout cannot prove cancellation at the provider. The synthetic ledger
 uses a UNIQUE key in a separate SQLite transaction to implement this contract.
+
+At or after `retryStartBefore`, `begin` grants no new retry lease. A currently
+active lease still returns `busy`; after that lease expires the outcome becomes
+`indeterminate`. `renew` extends ownership without changing retry admission, and
+an active owner may complete after the admission cutoff. Completed results replay
+without the provider, including after the cutoff. The [admission tests and timing
+counterexample](../tests/retry-window.test.ts) keep these guarantees separate.
 
 An exception from storage authorizes no tool call. A storage exception after a
 tool call or from `complete` is an ambiguous outcome: retry the same completion
@@ -52,7 +73,7 @@ expiry. An expired lease cannot be resurrected, even if no replacement exists.
 `settle` trusts the caller's externally verified receipt. Before settlement, stop
 or otherwise quiesce old executors so a late external effect cannot contradict the
 receipt. The library cannot prove this precondition. There is no reset/retry API
-for manual actions in v0.1.
+for indeterminate actions in v0.2.
 
 ## Storage and clock assumptions
 
@@ -81,9 +102,26 @@ inside the storage transaction after acquiring its lock. Tests inject time to
 reach exact boundaries without sleeps. Power failure, hardware loss and arbitrary
 disk corruption are outside the process-kill experiment.
 
+The cutoff uses that same host clock. An undetected backward clock adjustment can
+extend real elapsed admission time; the journal is not a trusted clock service.
+Once an operation becomes indeterminate it stays so even if the clock moves back.
+Use a stable time source and account for clock error in the integration's contract.
+
+Schema v2 retains v1 identities and fingerprints. On opening a v1 SQLite journal,
+the adapter validates and re-encodes records using bounded keyset iteration, then
+updates schema metadata in the same transaction. New time fields are null, never inferred from `leaseUntil` or
+reset to the current time. Completed records replay. Pending legacy idempotent
+records can complete under an active lease, but become indeterminate after expiry;
+their unknown historical window never authorizes a new attempt. Manual recovery
+keeps its existing behavior. An invalid old record rolls back the whole migration.
+Stop old executors and take a consistent backup before upgrading. The v2 metadata
+rejects newly opened v1 clients; version guards also reject writes from an already
+opened v1 client. These guards cannot cancel work that client has already sent.
+Downgrading a migrated database is unsupported. See [upgrade steps](retry-admission.md).
+
 Input fingerprints are retained instead of raw tool input. Results are stored as
 plaintext JSON. Hashes can reveal low-entropy input through guessing. Protect the
-database and choose result contents accordingly. v0.1 performs no authentication,
+database and choose result contents accordingly. v0.2 performs no authentication,
 encryption, retention cleanup or secure erasure.
 
 Canonical JSON sorts object keys, preserves array order and rejects unsupported

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -88,6 +88,10 @@ adapter has neither process coordination nor crash durability. Records with inva
 field types, unknown fields, impossible state combinations or noncanonical results
 throw; they never become a fresh journal. This validates structure, not authenticity:
 someone who can rewrite the database can also forge a structurally valid receipt.
+An existing journal with a missing table, missing schema version or multiple
+version rows is rejected. Opening it does not reconstruct lost state as an empty
+journal. A new database path still creates a new journal; protect the database
+file and restore a consistent backup if it is lost.
 
 Both adapters reject nested transactions and asynchronous callbacks. The callback
 must return a `Change` synchronously. Rejection prevents a returned change from being

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -28,8 +28,17 @@ than execution. Manual recovery cannot distinguish a lost receipt from a tool th
 never started. We accept this false-positive uncertainty. Automatically treating
 it as failure would permit duplicate side effects.
 
+## Bound retry admission without discarding a live receipt
+
+Provider key retention is finite. v0.2 records a fixed admission cutoff, while
+keeping lease ownership separate so an active executor can record its receipt
+after new retries have been barred. We cannot turn that cutoff into a network
+arrival guarantee. v1 records have no first-acquisition timestamp; migration must
+preserve that absence rather than grant them a new window at upgrade time.
+
 ## No expired-entry cleanup yet
 
 Deleting a completed record makes its key executable again. Cleanup therefore
 needs an explicit maximum retry horizon and a downstream retention agreement.
-v0.1 retains entries indefinitely rather than hiding this policy in a TTL.
+v0.2 retains entries even after admission closes. Deleting the record would also
+delete its cutoff and permit a new first acquisition under the same key.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -28,7 +28,9 @@ acknowledged over IPC before the parent terminates the child and starts recovery
 Kill points: before the effect, after committing the effect, and after recording
 completion. A fourth case drops the response after the effect, reports the transport
 failure, and starts a new recovery process. The clock is logical: acquisition at 100 ms, lease expiry at 110 ms,
-recovery at 111 ms. No actual ten-millisecond timing claim is made. POSIX uses
+recovery at 111 ms. In v0.2, journal idempotent operations use a 1,000 ms admission
+window anchored at that first acquisition; this matrix recovers inside the window.
+The synthetic provider retains keys indefinitely. No actual ten-millisecond timing claim is made. POSIX uses
 SIGKILL; Node forcefully terminates the process on Windows.
 
 The baselines are small implementations included in [worker.ts](../tests/fixtures/worker.ts):
@@ -55,11 +57,16 @@ run. CI runs the same matrix and uploads its report. Historical protocol 1 resul
 above remain tied to the original release and must not be relabeled as protocol 2.
 
 The independent model uses seed 20260908 for 500 MemoryStore histories and 40 SQLite
-histories of up to 100 commands. Each adapter also runs a 23-command exact-boundary
-walk, and coverage assertions require 26 observable protocol paths. Commands cover
+histories of up to 100 commands. Each adapter also runs 23-command and 21-command
+exact-boundary walks, and coverage assertions require 31 observable protocol paths. Commands cover
 renewal, settlement, input/result mutation, old handles, multiple namespaces,
-rollback and connection reopening. fast-check shrinks failing random sequences.
+rollback, fixed retry admission windows and connection reopening. fast-check shrinks failing random sequences.
 This is bounded model-based testing, not an exhaustive proof of all interleavings.
+
+Separate [retry admission tests](../tests/retry-window.test.ts) exercise a finite
+synthetic provider retention period: post-cutoff acquisition is refused, while an
+already-authorized request can still arrive after key eviction and duplicate an
+effect. These are separate tests, not additional cases folded into the 100-run matrix.
 
 ## HTTP receipt loss
 

--- a/docs/retry-admission.md
+++ b/docs/retry-admission.md
@@ -1,0 +1,89 @@
+# A deadline for granting retries
+
+A provider may eventually discard an idempotency key. Retrying the old operation
+after that point can create another effect even when the request uses the same key.
+tool-journal v0.2 therefore requires an explicit finite window for new retry leases:
+
+```ts
+const intent = {
+  scope: 'synthetic-example', key: 'append-42', tool: 'append', input: { units: 7 },
+  recovery: 'idempotent' as const, retryForMs: 60_000,
+};
+const begun = journal.begin(intent);
+if (begun.kind === 'acquired') console.log(begun.retryStartBefore);
+```
+
+The one-minute value is an example, not a recommendation for a real provider.
+The first acquisition stores its clock reading and the derived cutoff in the same
+transaction. Repeating the operation in another process or graph thread does not
+restart the window. Changing `retryForMs` conflicts with the stored policy. A
+manual operation omits `retryForMs` entirely.
+
+## Admission and ownership are different
+
+`retryStartBefore` limits when a new execution lease may be issued. The lease's
+own deadline limits which executor may record completion. These have different
+jobs:
+
+| At or after the admission cutoff | Result |
+| --- | --- |
+| A completed receipt exists | Replay it locally |
+| A pending lease is still active | Return busy; its owner can complete or renew |
+| The pending lease has expired | Persist indeterminate; issue no retry lease |
+| The operator has independently reconciled an indeterminate action | Allow explicit settlement after old executors are quiescent |
+
+Renewal does not extend admission. A cutoff reached exactly is closed. Once
+indeterminate, moving the clock backward does not restore retry permission.
+
+## What the cutoff cannot establish
+
+Suppose a synthetic provider deletes its key at time 100. A retry is authorized at
+99, pauses, and arrives at 101. The provider can commit a second effect. The same
+problem exists when an old executor wakes up after another executor has finished.
+Rejecting a stale journal completion does not undo that external effect. A client
+timeout stops waiting; it is not proof of server-side cancellation.
+
+The [regression suite](../tests/retry-window.test.ts) includes both the rejected
+post-cutoff acquisition and this delayed-arrival counterexample. The latter is
+intentional evidence of a limit, not a claim that the journal prevents it.
+
+Provider contracts differ. [Stripe](https://docs.stripe.com/api/idempotent_requests)
+allows keys to be cleaned up after at least 24 hours. [DynamoDB transaction tokens](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html)
+have a ten-minute window after the first request completes. [PayPal](https://developer.paypal.com/api/rest/reference/idempotency/)
+states that storage duration depends on the API. Check the actual endpoint, key
+scope, payload binding and retention policy; do not infer them from a generic SDK
+retry option.
+
+Anchoring the window at first journal acquisition assumes that the key has never
+been used downstream before. A conservative safety margin also needs justified
+bounds on delay and clock error. An ordinary HTTP timeout is not a maximum request
+arrival time. Stronger external guarantees require the provider to enforce a
+deadline/fencing contract or a durable business uniqueness constraint itself.
+
+## Upgrading a v0.1 journal
+
+1. Stop every old executor, including background retries. Reconcile outstanding
+   external work where possible. A database upgrade cannot stop an HTTP request.
+2. Take a consistent backup using [SQLite's backup facilities](https://sqlite.org/backup.html) or after a clean
+   shutdown of all connections. Do not copy only the main file while a WAL writer
+   is active. Keep the matching application version and integration configuration.
+3. Update idempotent intents to supply a fixed `retryForMs`. Keep scope, key, tool,
+   input and recovery mode unchanged. Do not assign a new key to bypass uncertainty.
+4. Open the database with v0.2. The adapter validates and re-encodes v1 rows and
+   updates schema metadata in one transaction, with bounded memory. A failure rolls back;
+   investigate it instead of deleting the journal or creating an empty replacement.
+5. Completed legacy records replay. Pending legacy idempotent records have no
+   knowable retry window: an active owner can still finish, but after lease expiry
+   `begin` returns indeterminate. Use independently verified evidence with `settle`;
+   adding `retryForMs` cannot manufacture a fresh window for an old operation.
+
+`firstAcquiredAt`, `retryForMs` and `retryStartBefore` are all null for legacy rows.
+The last lease deadline cannot recover the first acquisition time because it may
+have been renewed or replaced. Manual recovery is unchanged. A migrated completed
+receipt can replay with the new caller's configured window because that historical
+window is unknown and replay issues no external request.
+
+v0.1 clients reject schema v2 on opening. SQLite guards also reject their v1-format
+writes if they already had a connection open. Mixed-version operation and database
+downgrades are unsupported. Custom Store adapters must persist all v2 fields and
+provide their own atomic migration; the memory adapter has no durable v1 history.

--- a/examples/http-recovery.ts
+++ b/examples/http-recovery.ts
@@ -17,7 +17,8 @@ try {
       store = new SqliteStore(join(dir, `${recovery}-journal.sqlite`));
       let now = 100;
       const journal = new Journal(store, () => now);
-      const intent: Intent = { scope: 'http-demo', key: 'append-seven', tool: 'append', input: { units: 7 }, recovery };
+      const intent: Intent = { scope: 'http-demo', key: 'append-seven', tool: 'append', input: { units: 7 },
+        ...(recovery === 'manual' ? { recovery } : { recovery, retryForMs: 60_000 }) };
       service.dropNextReply(recovery);
       const first = await appendWithJournal(journal, service.port, intent, 10);
       assert.equal(first.kind, 'unconfirmed');

--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -29,7 +29,7 @@ labels tool-journal as **extraneous**. Run `npm run prepare` after changing the
 root library, or after a command that prunes unlisted packages. No archive or
 registry publication is needed in this example's Git history.
 
-`@langchain/langgraph` is pinned to 1.4.14, `@langchain/core` to 1.1.48,
+`@langchain/langgraph` is pinned to 1.4.14, `@langchain/core` to 1.2.9,
 `@langchain/langgraph-checkpoint-sqlite` to 1.0.4, and its native `better-sqlite3`
 dependency to 12.10.0. The native dependency supports Node 24 and 26 in its
 published engine range. Installation may require a compiler when a matching
@@ -71,6 +71,13 @@ Changing the units or recovery contract under that identity produces `conflict`
 before another HTTP request. A different intended operation needs a different
 application key. The graph thread ID remains LangGraph's state identity, not an
 HTTP idempotency key.
+
+The synthetic service retains its keys indefinitely. The graph still assigns
+idempotent operations a fixed 60,000 ms retry admission window from their first
+journal acquisition. Another graph thread cannot reset it. An expired lease after
+that window becomes indeterminate; completed receipts continue to replay. This
+cutoff does not bound when an already-authorized HTTP request reaches the service.
+See [retry admission and v0.1 database migration](../../docs/retry-admission.md).
 
 ## What the example and tests demonstrate
 

--- a/integrations/langgraph/graph.ts
+++ b/integrations/langgraph/graph.ts
@@ -1,6 +1,6 @@
 import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
 import { SqliteSaver } from '@langchain/langgraph-checkpoint-sqlite';
-import { Journal, SqliteStore, type Begin, type Completion, type Json } from '@raycarllei/tool-journal';
+import { Journal, SqliteStore, type Begin, type Completion, type Intent, type Json } from '@raycarllei/tool-journal';
 import { z } from 'zod';
 import { requestReceipt } from '#synthetic-http';
 import { join } from 'node:path';
@@ -54,7 +54,10 @@ export function openRuntime(directory: string, servicePort: number, options: Run
       const action = ActionSchema.parse(state.action);
       // Logical operation identity comes from the application. LangGraph thread,
       // checkpoint, task, and retry IDs never become a new downstream action key.
-      const intent = { scope: action.scope, key: action.key, tool: 'synthetic-http-append', input: { units: action.units }, recovery: action.recovery };
+      // The synthetic provider retains keys indefinitely. This example still
+      // bounds new retry authorization to one minute from the first acquisition.
+      const intent: Intent = { scope: action.scope, key: action.key, tool: 'synthetic-http-append', input: { units: action.units },
+        ...(action.recovery === 'manual' ? { recovery: action.recovery } : { recovery: action.recovery, retryForMs: 60_000 }) };
       const begun = journal.begin(intent, leaseMs);
       if (begun.kind !== 'acquired') return { outcome: begun };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycarllei/tool-journal",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "24.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Durable tool execution with lease fencing, explicit uncertainty, and reproducible crash tests.",
   "license": "MIT",
   "type": "module",

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -42,7 +42,7 @@ try {
   writeFileSync(join(directory, 'consumer.mjs'), `
 import assert from 'node:assert/strict';
 import { Journal, SqliteStore } from '@raycarllei/tool-journal';
-const intent = { scope: 'package-check', key: 'once', tool: 'append', input: { units: 7 }, recovery: 'idempotent' };
+const intent = { scope: 'package-check', key: 'once', tool: 'append', input: { units: 7 }, recovery: 'idempotent', retryForMs: 60000 };
 let store = new SqliteStore('journal.sqlite');
 const journal = new Journal(store, () => 100);
 const begun = journal.begin(intent);
@@ -60,6 +60,13 @@ const intent: Intent = { scope: 'types', key: 'one', tool: 'append', input: null
 const journal = new Journal(new MemoryStore());
 const result: Begin = journal.begin(intent);
 if (result.kind === 'acquired') journal.complete(result.lease, { receipt: 1 });
+const retryable: Intent = { ...intent, recovery: 'idempotent', retryForMs: 60000 };
+const admitted = journal.begin(retryable);
+if (admitted.kind === 'acquired') { const cutoff: number | null = admitted.retryStartBefore; void cutoff; }
+// @ts-expect-error An idempotent operation requires a finite admission window.
+const missingWindow: Intent = { scope: 'types', key: 'two', tool: 'append', input: null, recovery: 'idempotent' };
+// @ts-expect-error A manual operation cannot acquire a retry policy accidentally.
+const manualWindow: Intent = { scope: 'types', key: 'three', tool: 'append', input: null, recovery: 'manual', retryForMs: 60000 };
 `);
   run([join(root, 'node_modules/typescript/bin/tsc'), '--noEmit', '--strict', '--module', 'NodeNext',
     '--moduleResolution', 'NodeNext', '--target', 'ES2023', 'consumer.mts']);

--- a/scripts/mutations.mjs
+++ b/scripts/mutations.mjs
@@ -8,13 +8,14 @@ const original = readFileSync(file, 'utf8');
 const faults = [
   ['ignore changed input', 'entry.fingerprint !== fingerprint', 'false'],
   ['accept stale execution epochs', 'entry.epoch === lease.epoch && entry.executor === lease.executor', 'true'],
-  ['retry an uncertain manual action', "entry.recovery === 'manual'", 'false'],
+  ['retry without recovery authority', "entry.recovery === 'manual' || entry.retryStartBefore === null || now >= entry.retryStartBefore", 'false'],
+  ['admit a retry at or after its cutoff', 'now >= entry.retryStartBefore', 'false'],
   ['allow completion after lease expiry', 'entry.leaseUntil <= this.now()', 'false'],
   ['resurrect an expired lease', "entry.state !== 'pending' || entry.leaseUntil <= now", "entry.state !== 'pending'"],
   ['shorten a renewed lease', 'Math.max(entry.leaseUntil, deadline)', 'deadline'],
   ['settle before uncertainty', "entry.state !== 'indeterminate'", 'false'],
 ];
-const tests = ['--test', 'dist/tests/journal.test.js', 'dist/tests/model.test.js', 'dist/tests/integrity.test.js'];
+const tests = ['--test', 'dist/tests/journal.test.js', 'dist/tests/model.test.js', 'dist/tests/integrity.test.js', 'dist/tests/retry-window.test.js'];
 const baseline = spawnSync(process.execPath, tests, { encoding: 'utf8', windowsHide: true, timeout: 30_000 });
 if (baseline.status !== 0) throw new Error('Baseline tests must pass before mutation checks');
 let failed = false;

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -2,31 +2,41 @@ import { randomUUID } from 'node:crypto';
 import { canonical, digest, type Json } from './json.js';
 import type { Entry, Recovery, Store } from './record.js';
 
-export interface Intent {
+interface ActionIdentity {
   scope: string;
   key: string;
   tool: string;
   input: Json;
-  /** Idempotent means the downstream enforces this key for the entire retry horizon. */
-  recovery: Recovery;
 }
+export type Intent = ActionIdentity & (
+  | { recovery: 'manual'; retryForMs?: never }
+  /** A fixed admission window from first acquisition, not a provider expiry guarantee. */
+  | { recovery: 'idempotent'; retryForMs: number }
+);
 export interface Lease { readonly id: string; readonly epoch: number; readonly executor: string }
 export type Begin =
-  | { kind: 'acquired'; lease: Lease; retry: boolean }
+  | { kind: 'acquired'; lease: Lease; retry: boolean; retryStartBefore: number | null }
   | { kind: 'replay'; result: Json }
   | { kind: 'busy'; leaseUntil: number }
   | { kind: 'conflict' }
   | { kind: 'indeterminate' };
 export type Completion = { kind: 'completed' | 'replayed' | 'stale' | 'conflict' };
 
-function identity(intent: Intent): { id: string; fingerprint: string } {
-  for (const text of [intent.scope, intent.key, intent.tool]) {
+function identity(intent: Intent): { id: string; fingerprint: string; recovery: Recovery; retryForMs: number | null } {
+  const { scope, key, tool, input, recovery, retryForMs } = intent;
+  for (const text of [scope, key, tool]) {
     if (typeof text !== 'string' || text.length === 0 || text.length > 512) throw new TypeError('Invalid intent identifier');
   }
-  if (intent.recovery !== 'idempotent' && intent.recovery !== 'manual') throw new TypeError('Invalid recovery contract');
+  if (recovery !== 'idempotent' && recovery !== 'manual') throw new TypeError('Invalid recovery contract');
+  if (recovery === 'idempotent') {
+    if (!Number.isSafeInteger(retryForMs) || retryForMs < 1) throw new TypeError('Retry window must be positive safe integer milliseconds');
+  } else if (retryForMs !== undefined) throw new TypeError('Manual recovery cannot have a retry window');
   return {
-    id: digest(canonical([intent.scope, intent.key])),
-    fingerprint: digest(canonical([intent.tool, intent.input, intent.recovery])),
+    id: digest(canonical([scope, key])),
+    // Preserve v1 identity/fingerprints so migration can replay known receipts.
+    // The new policy is bound separately; it may never refresh an existing window.
+    fingerprint: digest(canonical([tool, input, recovery])),
+    recovery, retryForMs: retryForMs ?? null,
   };
 }
 
@@ -49,26 +59,33 @@ export class Journal {
   }
 
   begin(intent: Intent, leaseMs = 30_000): Begin {
-    const { id, fingerprint } = identity(intent);
+    const { id, fingerprint, recovery, retryForMs } = identity(intent);
     return this.store.transact<Begin>(id, entry => {
       // Read time after acquiring the storage lock; lock contention may outlast a lease.
       const now = this.now();
       const leaseUntil = this.deadline(now, leaseMs);
       if (entry) {
         if (entry.fingerprint !== fingerprint) return { value: { kind: 'conflict' } };
+        if (entry.retryForMs !== null && entry.retryForMs !== retryForMs) return { value: { kind: 'conflict' } };
         if (entry.state === 'completed') return { value: { kind: 'replay', result: JSON.parse(entry.result!) as Json } };
         if (entry.state === 'indeterminate') return { value: { kind: 'indeterminate' } };
         if (entry.leaseUntil > now) return { value: { kind: 'busy', leaseUntil: entry.leaseUntil } };
-        if (entry.recovery === 'manual') return {
+        if (entry.recovery === 'manual' || entry.retryStartBefore === null || now >= entry.retryStartBefore) return {
           value: { kind: 'indeterminate' }, next: { ...entry, state: 'indeterminate' },
         };
       }
       const epoch = (entry?.epoch ?? 0) + 1;
       if (!Number.isSafeInteger(epoch)) throw new Error('Execution epoch exhausted');
       const executor = randomUUID();
+      const firstAcquiredAt = entry ? entry.firstAcquiredAt : now;
+      const retryStartBefore = entry ? entry.retryStartBefore : retryForMs === null ? null : now + retryForMs;
+      if (retryStartBefore !== null && !Number.isSafeInteger(retryStartBefore)) {
+        throw new TypeError('Retry admission deadline exceeds safe integer range');
+      }
       return {
-        value: { kind: 'acquired', lease: { id, epoch, executor }, retry: entry !== undefined },
-        next: { version: 1, id, fingerprint, recovery: intent.recovery, state: 'pending', epoch, executor, leaseUntil, result: null },
+        value: { kind: 'acquired', lease: { id, epoch, executor }, retry: entry !== undefined, retryStartBefore },
+        next: { version: 2, id, fingerprint, recovery, state: 'pending', epoch, executor, leaseUntil, result: null,
+          firstAcquiredAt, retryForMs, retryStartBefore },
       };
     });
   }
@@ -94,11 +111,12 @@ export class Journal {
 
   /** Call only after quiescing old executors and independently verifying the downstream receipt. */
   settle(intent: Intent, verifiedResult: Json): 'settled' | 'replayed' | 'conflict' | 'not_indeterminate' {
-    const { id, fingerprint } = identity(intent);
+    const { id, fingerprint, retryForMs } = identity(intent);
     const result = canonical(verifiedResult);
     return this.store.transact(id, entry => {
       if (!entry) return { value: 'not_indeterminate' };
       if (entry.fingerprint !== fingerprint) return { value: 'conflict' };
+      if (entry.retryForMs !== null && entry.retryForMs !== retryForMs) return { value: 'conflict' };
       if (entry.state === 'completed') return { value: entry.result === result ? 'replayed' : 'conflict' };
       if (entry.state !== 'indeterminate') return { value: 'not_indeterminate' };
       return { value: 'settled', next: { ...entry, state: 'completed', result } };

--- a/src/record.ts
+++ b/src/record.ts
@@ -4,7 +4,7 @@ import { types } from 'node:util';
 export type Recovery = 'idempotent' | 'manual';
 
 export interface Entry {
-  version: 1;
+  version: 2;
   id: string;
   fingerprint: string;
   recovery: Recovery;
@@ -13,28 +13,48 @@ export interface Entry {
   executor: string;
   leaseUntil: number;
   result: string | null;
+  /** null only for a migrated v1 record whose first acquisition is unknown. */
+  firstAcquiredAt: number | null;
+  /** null for manual recovery or a migrated idempotent record with no known window. */
+  retryForMs: number | null;
+  retryStartBefore: number | null;
 }
 
 /** Invalid persisted state must stop execution, never be treated as an empty journal. */
-export function decodeEntry(raw: string, id: string): Entry {
+export function decodeEntry(raw: string, id: string, version: 1 | 2 = 2): Entry {
   // A canonical result is nested as a JSON string, which can double its byte size.
   const limit = 2 * MAX_JSON_BYTES + 4_096;
   if (raw.length > limit || Buffer.byteLength(raw) > limit) throw new Error('Corrupt journal entry: oversized record');
-  const v: unknown = JSON.parse(raw);
+  let v: unknown;
+  try { v = JSON.parse(raw); }
+  catch (cause) { throw new Error('Corrupt journal entry: invalid JSON', { cause }); }
   if (typeof v !== 'object' || v === null || Array.isArray(v)) throw new Error('Corrupt journal entry');
   const e = v as Record<string, unknown>;
   const fields = ['version', 'id', 'fingerprint', 'recovery', 'state', 'epoch', 'executor', 'leaseUntil', 'result'];
+  if (version === 2) fields.push('firstAcquiredAt', 'retryForMs', 'retryStartBefore');
   if (Object.keys(e).length !== fields.length || fields.some(field => !Object.hasOwn(e, field)) ||
-      e.version !== 1 || e.id !== id || typeof e.id !== 'string' || !/^[a-f0-9]{64}$/.test(e.id) ||
+      e.version !== version || e.id !== id || typeof e.id !== 'string' || !/^[a-f0-9]{64}$/.test(e.id) ||
       typeof e.fingerprint !== 'string' || !/^[a-f0-9]{64}$/.test(e.fingerprint) ||
       (e.recovery !== 'idempotent' && e.recovery !== 'manual') ||
       (e.state !== 'pending' && e.state !== 'completed' && e.state !== 'indeterminate') ||
-      (e.state === 'indeterminate' && e.recovery !== 'manual') ||
+      (version === 1 && e.state === 'indeterminate' && e.recovery !== 'manual') ||
       !Number.isSafeInteger(e.epoch) || Number(e.epoch) < 1 ||
       typeof e.executor !== 'string' || e.executor.length === 0 || e.executor.length > 512 ||
       !Number.isSafeInteger(e.leaseUntil) || Number(e.leaseUntil) < 0 ||
       (e.state === 'completed' ? typeof e.result !== 'string' : e.result !== null)) {
     throw new Error('Corrupt journal entry');
+  }
+  if (version === 2) {
+    const firstKnown = Number.isSafeInteger(e.firstAcquiredAt) && Number(e.firstAcquiredAt) >= 0;
+    if (firstKnown && Number(e.leaseUntil) <= Number(e.firstAcquiredAt)) {
+      throw new Error('Corrupt journal entry: lease precedes first acquisition');
+    }
+    const unknownWindow = e.firstAcquiredAt === null && e.retryForMs === null && e.retryStartBefore === null;
+    const boundedWindow = firstKnown && Number.isSafeInteger(e.retryForMs) && Number(e.retryForMs) > 0 &&
+      Number.isSafeInteger(e.retryStartBefore) && Number(e.retryStartBefore) === Number(e.firstAcquiredAt) + Number(e.retryForMs);
+    if (e.recovery === 'manual'
+      ? ((!firstKnown && e.firstAcquiredAt !== null) || e.retryForMs !== null || e.retryStartBefore !== null)
+      : (!unknownWindow && !boundedWindow)) throw new Error('Corrupt journal entry: invalid retry window');
   }
   if (e.state === 'completed') {
     try {
@@ -43,7 +63,9 @@ export function decodeEntry(raw: string, id: string): Entry {
       throw new Error('Corrupt journal entry: invalid result', { cause });
     }
   }
-  return e as unknown as Entry;
+  return (version === 1
+    ? { ...e, version: 2, firstAcquiredAt: null, retryForMs: null, retryStartBefore: null }
+    : e) as unknown as Entry;
 }
 
 export function encodeEntry(entry: Entry, id: string): string {

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -12,9 +12,32 @@ export class SqliteStore implements Store {
       this.db.exec('BEGIN IMMEDIATE');
       this.db.exec('CREATE TABLE IF NOT EXISTS journal_meta (version INTEGER NOT NULL) STRICT');
       const versions = this.db.prepare('SELECT version FROM journal_meta').all();
-      if (versions.length === 0) this.db.prepare('INSERT INTO journal_meta VALUES (1)').run();
-      else if (versions.length !== 1 || versions[0]!.version !== 1) throw new Error('Unsupported journal schema');
+      if (versions.length === 0) this.db.prepare('INSERT INTO journal_meta VALUES (2)').run();
+      else if (versions.length !== 1 || ![1, 2].includes(Number(versions[0]!.version))) throw new Error('Unsupported journal schema');
       this.db.exec('CREATE TABLE IF NOT EXISTS tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT');
+      if (versions[0]?.version === 1) {
+        // Keyset iteration bounds memory without updating beneath an active cursor.
+        // Decode and re-encode with one JSON parser; SQL JSON functions can resolve
+        // duplicate object keys differently. Any bad row rolls back every write.
+        const read = this.db.prepare('SELECT id, entry FROM tool_journal WHERE id > ? ORDER BY id LIMIT 1');
+        const write = this.db.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?');
+        let row = this.db.prepare('SELECT id, entry FROM tool_journal ORDER BY id LIMIT 1').get();
+        while (row) {
+          const id = String(row.id);
+          const migrated = decodeEntry(String(row.entry), id, 1);
+          write.run(encodeEntry(migrated, id), id);
+          row = read.get(id);
+        }
+        this.db.exec('UPDATE journal_meta SET version = 2');
+      }
+      // A v1 process that already opened the database does not recheck metadata.
+      // Reject its writes too. This does not cancel an external request it sent.
+      for (const operation of ['INSERT', 'UPDATE'] as const) {
+        this.db.exec(`CREATE TRIGGER IF NOT EXISTS tool_journal_v2_${operation.toLowerCase()}
+          BEFORE ${operation} ON tool_journal
+          WHEN CASE WHEN json_valid(NEW.entry) THEN json_extract(NEW.entry, '$.version') IS 2 ELSE 0 END = 0
+          BEGIN SELECT RAISE(ABORT, 'Unsupported journal entry version'); END;`);
+      }
       this.db.exec('COMMIT');
     } catch (error) {
       this.abort(error, true);

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -10,11 +10,15 @@ export class SqliteStore implements Store {
     try {
       this.db.exec('PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;');
       this.db.exec('BEGIN IMMEDIATE');
-      this.db.exec('CREATE TABLE IF NOT EXISTS journal_meta (version INTEGER NOT NULL) STRICT');
-      const versions = this.db.prepare('SELECT version FROM journal_meta').all();
-      if (versions.length === 0) this.db.prepare('INSERT INTO journal_meta VALUES (2)').run();
-      else if (versions.length !== 1 || ![1, 2].includes(Number(versions[0]!.version))) throw new Error('Unsupported journal schema');
-      this.db.exec('CREATE TABLE IF NOT EXISTS tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT');
+      const tables = this.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('journal_meta', 'tool_journal')").all();
+      if (tables.length === 0) {
+        this.db.exec('CREATE TABLE journal_meta (version INTEGER NOT NULL) STRICT; INSERT INTO journal_meta VALUES (2); CREATE TABLE tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT;');
+      } else if (tables.length !== 2) {
+        // Recreating a missing records table would forget completed effects.
+        throw new Error('Unsupported journal schema: missing table');
+      }
+      const versions = this.db.prepare('SELECT version FROM journal_meta LIMIT 2').all();
+      if (versions.length !== 1 || ![1, 2].includes(Number(versions[0]!.version))) throw new Error('Unsupported journal schema');
       if (versions[0]?.version === 1) {
         // Keyset iteration bounds memory without updating beneath an active cursor.
         // Decode and re-encode with one JSON parser; SQL JSON functions can resolve

--- a/tests/fixtures/worker.ts
+++ b/tests/fixtures/worker.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
-import { Journal, SqliteStore, type Json } from '../../src/index.js';
+import { Journal, SqliteStore, type Intent, type Json } from '../../src/index.js';
 import { canonical, digest } from '../../src/json.js';
 
 const [journalPath, ledgerPath, strategy, phase, time] = process.argv.slice(2) as [string, string, string, string, string];
@@ -41,7 +41,8 @@ async function pause(at: string): Promise<void> {
 const usesJournal = strategy.startsWith('journal') || strategy === 'claim';
 const store = usesJournal ? new SqliteStore(journalPath) : undefined;
 const journal = store ? new Journal(store, () => now) : undefined;
-const intent = { scope: 'synthetic-ledger', key: 'append-7', tool: 'append', input: { units: 7 }, recovery: strategy === 'journal-manual' ? 'manual' as const : 'idempotent' as const };
+const intent: Intent = { scope: 'synthetic-ledger', key: 'append-7', tool: 'append', input: { units: 7 },
+  ...(strategy === 'journal-manual' ? { recovery: 'manual' as const } : { recovery: 'idempotent' as const, retryForMs: 1_000 }) };
 // Identical downstream identity in both deduplicating strategies. Keep this check
 // separate from the journal so the baseline does not acquire or read journal state.
 const downstreamKey = digest(canonical([intent.scope, intent.key]));

--- a/tests/http-recovery.test.ts
+++ b/tests/http-recovery.test.ts
@@ -10,7 +10,7 @@ import { appendWithJournal, requestReceipt, ReceiptUnavailable, MAX_RESPONSE_BYT
 import { startSyntheticService, MAX_REQUEST_BYTES, type SyntheticService } from '../examples/http/service.js';
 
 const key = 'a'.repeat(64);
-const intent: Intent = { scope: 'http-test', key: 'append-seven', tool: 'append', input: { units: 7 }, recovery: 'idempotent' };
+const operation = { scope: 'http-test', key: 'append-seven', tool: 'append', input: { units: 7 } };
 
 for (const recovery of ['idempotent', 'manual'] as const) {
   test(`HTTP ${recovery}: lost receipt survives reopening both independent stores`, async () => {
@@ -23,7 +23,7 @@ for (const recovery of ['idempotent', 'manual'] as const) {
       service = await startSyntheticService(downstreamPath);
       store = new SqliteStore(journalPath);
       let journal = new Journal(store, () => now);
-      const action = { ...intent, recovery };
+      const action: Intent = { ...operation, ...(recovery === 'manual' ? { recovery } : { recovery, retryForMs: 60_000 }) };
       service.dropNextReply(recovery);
       assert.deepEqual(await appendWithJournal(journal, service.port, action, 10), { kind: 'unconfirmed', reason: 'transport' });
       const committed = service.snapshot();
@@ -230,7 +230,7 @@ test('a receipt arriving after lease expiry is returned as stale, never complete
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end('{"receipt":1,"units":7}');
     });
-    const action: Intent = { ...intent, recovery: 'manual' };
+    const action: Intent = { ...operation, recovery: 'manual' };
     assert.deepEqual(await appendWithJournal(journal, service.port, action, 10), { kind: 'stale', result: { receipt: 1, units: 7 } });
     assert.deepEqual(await appendWithJournal(journal, service.port, action, 10), { kind: 'indeterminate' });
     assert.equal(service.calls(), 1);

--- a/tests/integrity.test.ts
+++ b/tests/integrity.test.ts
@@ -48,7 +48,7 @@ const malformedFields: Record<string, Record<string, unknown>> = {
   'array state that string-coerces to pending': { state: ['pending'] },
   'array fingerprint': { fingerprint: ['a'.repeat(64)] },
   'unknown field': { unexpected: true },
-  'indeterminate idempotent action': { recovery: 'idempotent', state: 'indeterminate' },
+  'idempotent action without a retry window': { recovery: 'idempotent', state: 'indeterminate' },
   'pending action with a receipt': { result: 'null' },
   'completed action without a receipt': { state: 'completed', result: null },
   'string epoch': { epoch: '1' },

--- a/tests/journal.test.ts
+++ b/tests/journal.test.ts
@@ -7,7 +7,8 @@ import { DatabaseSync } from 'node:sqlite';
 import { Journal, MemoryStore, SqliteStore, type Intent, type Lease } from '../src/index.js';
 import { canonical } from '../src/json.js';
 
-const intent: Intent = { scope: 'synthetic', key: 'action-1', tool: 'append', input: { units: 7 }, recovery: 'idempotent' };
+const action = { scope: 'synthetic', key: 'action-1', tool: 'append', input: { units: 7 } };
+const intent: Intent = { ...action, recovery: 'idempotent', retryForMs: 1_000 };
 function acquire(journal: Journal, value = intent): Lease {
   const result = journal.begin(value, 10);
   assert.equal(result.kind, 'acquired');
@@ -26,7 +27,7 @@ for (const adapter of ['memory', 'sqlite'] as const) {
       assert.equal(journal.begin(intent).kind, 'busy');
       assert.equal(journal.begin({ ...intent, input: { units: 8 } }).kind, 'conflict');
       assert.equal(journal.begin({ ...intent, tool: 'delete' }).kind, 'conflict');
-      assert.equal(journal.begin({ ...intent, recovery: 'manual' }).kind, 'conflict');
+      assert.equal(journal.begin({ ...action, recovery: 'manual' }).kind, 'conflict');
       now = 110;
       assert.equal(journal.complete(first, null).kind, 'stale');
       assert.equal(journal.renew(first), false);
@@ -52,7 +53,7 @@ for (const adapter of ['memory', 'sqlite'] as const) {
 test('manual recovery blocks retries until an independently verified settlement', () => {
   let now = 0;
   const j = new Journal(new MemoryStore(), () => now);
-  const value: Intent = { ...intent, recovery: 'manual' };
+  const value: Intent = { ...action, recovery: 'manual' };
   const lease = acquire(j, value);
   assert.equal(j.settle(value, { receipt: 1 }), 'not_indeterminate');
   now = 10;
@@ -119,7 +120,7 @@ test('SQLite rollback, reopen, and corruption fail closed', () => {
     store.close(); store = new SqliteStore(path);
     assert.equal(new Journal(store).begin(intent).kind, 'replay');
     const raw = new DatabaseSync(path);
-    raw.prepare('UPDATE tool_journal SET entry = ?').run('{"version":9}');
+    raw.prepare('UPDATE tool_journal SET entry = ?').run('{"version":2}');
     raw.close();
     assert.throws(() => new Journal(store).begin(intent), /Corrupt/);
   } finally { store.close(); rmSync(dir, { recursive: true, force: true }); }

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -11,6 +11,7 @@ import { Journal, MemoryStore, SqliteStore, type Intent, type Lease, type Store 
 interface Account {
   phase: 'running' | 'uncertain' | 'finished';
   deadline: number;
+  stopStartingAt: number | null;
   owner: number;
   grants: number[];
   receipt: number | undefined;
@@ -33,7 +34,9 @@ function intent(slot: number, reverse = false): Intent {
   const [scope, key] = identities[slot]!;
   const request = { units: slot + 1, enabled: true };
   const input = reverse ? { request, tags: [slot, null] } : { tags: [slot, null], request };
-  return { scope, key, tool: 'append', input, recovery: slot % 2 === 0 ? 'manual' : 'idempotent' };
+  const common = { scope, key, tool: 'append', input };
+  return slot % 2 === 0 ? { ...common, recovery: 'manual' }
+    : { ...common, recovery: 'idempotent', retryForMs: 8 + slot };
 }
 function receipt(value: number, reverse = false) {
   const details = { labels: ['synthetic', value], verified: true };
@@ -47,7 +50,7 @@ type Action =
   | ({ op: 'complete'; holder: 'first' | 'current'; value: number; reverse: boolean } & Target)
   | ({ op: 'renew'; holder: 'first' | 'current'; duration: number } & Target)
   | ({ op: 'settle'; value: number; reverse: boolean } & Target)
-  | ({ op: 'conflict'; field: 'input' | 'tool' | 'recovery' } & Target)
+  | ({ op: 'conflict'; field: 'input' | 'tool' | 'recovery' | 'retryForMs' } & Target)
   | ({ op: 'abort' } & Target)
   | { op: 'reopen'; client: number };
 
@@ -56,7 +59,9 @@ class ContractCommand implements fc.Command<Model, Runtime> {
 
   check(model: Readonly<Model>): boolean {
     switch (this.action.op) {
-      case 'complete': case 'renew': case 'conflict': case 'abort':
+      case 'conflict':
+        return model.accounts.has(this.action.slot) && (this.action.field !== 'retryForMs' || this.action.slot % 2 === 1);
+      case 'complete': case 'renew': case 'abort':
         return model.accounts.has(this.action.slot);
       default: return true;
     }
@@ -84,8 +89,10 @@ class ContractCommand implements fc.Command<Model, Runtime> {
             assert.deepEqual(actual, { kind: 'indeterminate' });
           } else if (account && model.now < account.deadline) {
             assert.deepEqual(actual, { kind: 'busy', leaseUntil: account.deadline });
-          } else if (account && value.recovery === 'manual') {
+            if (account.stopStartingAt !== null && model.now >= account.stopStartingAt) real.observed.add('begin:busy-after-admission');
+          } else if (account && (value.recovery === 'manual' || model.now >= account.stopStartingAt!)) {
             assert.deepEqual(actual, { kind: 'indeterminate' });
+            if (value.recovery === 'idempotent') real.observed.add('begin:window-elapsed');
             account.phase = 'uncertain';
           } else {
             assert.equal(actual.kind, 'acquired');
@@ -97,9 +104,12 @@ class ContractCommand implements fc.Command<Model, Runtime> {
               assert.notEqual(actual.lease.executor, previous.executor);
             }
             const grant = model.nextGrant++;
+            const stopStartingAt = account?.stopStartingAt ?? (value.recovery === 'manual' ? null : model.now + value.retryForMs);
+            assert.equal(actual.retryStartBefore, stopStartingAt);
             real.leases.set(grant, actual.lease);
             model.accounts.set(action.slot, {
               phase: 'running', deadline: model.now + action.duration,
+              stopStartingAt,
               owner: grant, grants: [...(account?.grants ?? []), grant], receipt: undefined,
             });
           }
@@ -121,6 +131,7 @@ class ContractCommand implements fc.Command<Model, Runtime> {
           real.observed.add(`complete:${expected}`);
           if (!owns) real.observed.add('complete:retired');
           if (account!.phase === 'running' && model.now === account!.deadline) real.observed.add('complete:at-expiry');
+          if (canCommit && account!.stopStartingAt !== null && model.now >= account!.stopStartingAt) real.observed.add('complete:after-admission');
           if (canCommit) { account!.phase = 'finished'; account!.receipt = action.value; }
           value.details.labels.push('caller mutation');
           break;
@@ -132,6 +143,7 @@ class ContractCommand implements fc.Command<Model, Runtime> {
           real.observed.add(`renew:${allowed}`);
           if (allowed) real.observed.add(model.now + action.duration < account!.deadline ? 'renew:nonshortening' : 'renew:extended');
           if (account!.phase === 'running' && model.now === account!.deadline) real.observed.add('renew:at-expiry');
+          if (allowed && account!.stopStartingAt !== null && model.now >= account!.stopStartingAt) real.observed.add('renew:after-admission');
           if (allowed) account!.deadline = Math.max(account!.deadline, model.now + action.duration);
           break;
         }
@@ -148,10 +160,18 @@ class ContractCommand implements fc.Command<Model, Runtime> {
           break;
         }
         case 'conflict': {
-          const changed = intent(action.slot);
+          let changed = intent(action.slot);
           if (action.field === 'input') changed.input = { units: -1 };
           if (action.field === 'tool') changed.tool = 'different-tool';
-          if (action.field === 'recovery') changed.recovery = changed.recovery === 'manual' ? 'idempotent' : 'manual';
+          if (action.field === 'recovery') {
+            const common = { scope: changed.scope, key: changed.key, tool: changed.tool, input: changed.input };
+            changed = changed.recovery === 'manual' ? { ...common, recovery: 'idempotent', retryForMs: 10 }
+              : { ...common, recovery: 'manual' };
+          }
+          if (action.field === 'retryForMs' && changed.recovery === 'idempotent') {
+            changed.retryForMs += 1;
+            real.observed.add('conflict:retry-window');
+          }
           assert.deepEqual(journal.begin(changed), { kind: 'conflict' });
           assert.equal(journal.settle(changed, receipt(0)), 'conflict');
           break;
@@ -208,7 +228,7 @@ const commands = [
   fc.record({ op: fc.constant('complete' as const), slot, client, holder, value, reverse }),
   fc.record({ op: fc.constant('renew' as const), slot, client, holder, duration }),
   fc.record({ op: fc.constant('settle' as const), slot, client, value, reverse }),
-  fc.record({ op: fc.constant('conflict' as const), slot, client, field: fc.constantFrom('input' as const, 'tool' as const, 'recovery' as const) }),
+  fc.record({ op: fc.constant('conflict' as const), slot, client, field: fc.constantFrom('input' as const, 'tool' as const, 'recovery' as const, 'retryForMs' as const) }),
   fc.record({ op: fc.constant('abort' as const), slot, client }),
   fc.record({ op: fc.constant('reopen' as const), client }),
 ].map(arbitrary => arbitrary.map(action => new ContractCommand(action)));
@@ -275,6 +295,30 @@ for (const adapter of ['memory', 'sqlite'] as const) {
     };
     // Cover exact deadlines explicitly; random histories explore interleavings.
     run(boundary.map(action => new ContractCommand(action)));
+    const admissionBoundary: Action[] = [
+      { op: 'begin', slot: 1, client: 0, duration: 3, reverse: false },
+      { op: 'begin', slot: 3, client: 1, duration: 20, reverse: false },
+      { op: 'advance', elapsed: 3 },
+      { op: 'begin', slot: 1, client: 1, duration: 3, reverse: true },
+      { op: 'advance', elapsed: 3 },
+      { op: 'begin', slot: 1, client: 0, duration: 2, reverse: false },
+      { op: 'reopen', client: 0 },
+      { op: 'advance', elapsed: 2 },
+      { op: 'begin', slot: 1, client: 0, duration: 1, reverse: true },
+      { op: 'conflict', slot: 1, client: 1, field: 'retryForMs' },
+      { op: 'advance', elapsed: 1 },
+      { op: 'begin', slot: 1, client: 1, duration: 3, reverse: false },
+      { op: 'settle', slot: 1, client: 0, value: 1, reverse: false },
+      { op: 'begin', slot: 1, client: 1, duration: 3, reverse: true },
+      { op: 'conflict', slot: 1, client: 1, field: 'retryForMs' },
+      { op: 'advance', elapsed: 2 },
+      { op: 'begin', slot: 3, client: 0, duration: 3, reverse: false },
+      { op: 'renew', slot: 3, client: 1, holder: 'current', duration: 20 },
+      { op: 'complete', slot: 3, client: 0, holder: 'current', value: 2, reverse: false },
+      { op: 'conflict', slot: 3, client: 1, field: 'retryForMs' },
+      { op: 'reopen', client: 1 },
+    ];
+    run(admissionBoundary.map(action => new ContractCommand(action)));
     fc.assert(fc.property(fc.commands(commands, { maxCommands: 100, size: 'max' }), history => {
       run(history);
     }), {
@@ -290,6 +334,7 @@ for (const adapter of ['memory', 'sqlite'] as const) {
       'complete:at-expiry', 'renew:nonshortening', 'renew:extended', 'renew:at-expiry', 'settle:expired-running',
       'renew:true', 'renew:false', 'settle:settled', 'settle:replayed', 'settle:conflict', 'settle:not_indeterminate',
       'conflict', 'abort', 'reopen:running', 'reopen:uncertain', 'reopen:finished',
+      'begin:busy-after-admission', 'begin:window-elapsed', 'complete:after-admission', 'renew:after-admission', 'conflict:retry-window',
     ]) assert.ok(observed.has(outcome), `Histories did not exercise ${outcome}`);
   });
 }

--- a/tests/retry-window.test.ts
+++ b/tests/retry-window.test.ts
@@ -1,0 +1,419 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { Journal, MemoryStore, SqliteStore, type Intent, type Lease } from '../src/index.js';
+
+const intent: Intent = { scope: 'retry-window', key: 'one-action', tool: 'append', input: { units: 7 }, recovery: 'idempotent', retryForMs: 20 };
+
+function temporaryDirectory(): string {
+  const root = realpathSync(tmpdir());
+  const directory = realpathSync(mkdtempSync(join(root, 'journal-retry-window-')));
+  assert.equal(dirname(directory), root);
+  return directory;
+}
+
+interface Runtime {
+  now: number;
+  journal: Journal;
+  reopen(): void;
+}
+
+function withRuntime(adapter: 'memory' | 'sqlite', run: (runtime: Runtime) => void): void {
+  const directory = adapter === 'sqlite' ? temporaryDirectory() : undefined;
+  const memory = new MemoryStore();
+  let store = directory ? new SqliteStore(join(directory, 'journal.sqlite')) : memory;
+  const runtime: Runtime = {
+    now: 100,
+    journal: new Journal(store, () => runtime.now),
+    reopen() {
+      if (store instanceof SqliteStore) store.close();
+      store = directory ? new SqliteStore(join(directory, 'journal.sqlite')) : memory;
+      runtime.journal = new Journal(store, () => runtime.now);
+    },
+  };
+  try { run(runtime); }
+  finally {
+    if (store instanceof SqliteStore) store.close();
+    if (directory) rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function acquire(journal: Journal, value = intent, leaseMs = 5) {
+  const begun = journal.begin(value, leaseMs);
+  assert.equal(begun.kind, 'acquired');
+  if (begun.kind !== 'acquired') throw new Error('Expected a grant');
+  return begun;
+}
+
+for (const adapter of ['memory', 'sqlite'] as const) {
+  test(`${adapter}: only admissions strictly before the fixed cutoff can retry`, () => {
+    withRuntime(adapter, runtime => {
+      const first = acquire(runtime.journal);
+      assert.equal(first.retryStartBefore, 120);
+      assert.equal(first.retry, false);
+      runtime.now = 105;
+      const second = acquire(runtime.journal);
+      assert.equal(second.retryStartBefore, 120);
+      assert.equal(second.retry, true);
+      runtime.reopen();
+      runtime.now = 119;
+      const last = acquire(runtime.journal, intent, 1);
+      assert.equal(last.retryStartBefore, 120);
+      runtime.now = 120;
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'indeterminate' });
+      assert.equal(runtime.journal.complete(last.lease, { receipt: 1 }).kind, 'stale');
+      runtime.now = 121;
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'indeterminate' });
+      runtime.reopen();
+      runtime.now = 101; // A backward clock cannot undo a persisted decision.
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'indeterminate' });
+    });
+  });
+
+  test(`${adapter}: a live owner can renew and complete after admission closes`, () => {
+    withRuntime(adapter, runtime => {
+      const first = acquire(runtime.journal, intent, 30);
+      runtime.now = 120;
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'busy', leaseUntil: 130 });
+      assert.equal(runtime.journal.renew(first.lease, 50), true);
+      runtime.reopen();
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'busy', leaseUntil: 170 });
+      runtime.now = 169;
+      assert.equal(runtime.journal.complete(first.lease, { receipt: 1 }).kind, 'completed');
+      runtime.now = 1_000;
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+      assert.deepEqual(runtime.journal.begin({ ...intent, retryForMs: 21 }), { kind: 'conflict' });
+    });
+  });
+
+  test(`${adapter}: changed retry policy conflicts before and after uncertainty`, () => {
+    withRuntime(adapter, runtime => {
+      acquire(runtime.journal);
+      const changed: Intent = { ...intent, retryForMs: 21 };
+      assert.deepEqual(runtime.journal.begin(changed), { kind: 'conflict' });
+      runtime.now = 120;
+      assert.deepEqual(runtime.journal.begin(changed), { kind: 'conflict' });
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'indeterminate' });
+      assert.equal(runtime.journal.settle(changed, { receipt: 1 }), 'conflict');
+      assert.equal(runtime.journal.settle(intent, { receipt: 1 }), 'settled');
+      assert.deepEqual(runtime.journal.begin(changed), { kind: 'conflict' });
+      assert.deepEqual(runtime.journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+    });
+  });
+
+  test(`${adapter}: manual grants have no automatic recovery window`, () => {
+    withRuntime(adapter, runtime => {
+      const manual: Intent = { scope: intent.scope, key: intent.key, tool: intent.tool, input: intent.input, recovery: 'manual' };
+      const first = acquire(runtime.journal, manual);
+      assert.equal(first.retryStartBefore, null);
+      runtime.now = 105;
+      assert.deepEqual(runtime.journal.begin(manual), { kind: 'indeterminate' });
+    });
+  });
+}
+
+test('the initial retry window is anchored after storage lock acquisition', () => {
+  let now = 100;
+  const memory = new MemoryStore();
+  const journal = new Journal({ transact(id, change) { now = 150; return memory.transact(id, change); } }, () => now);
+  assert.equal(acquire(journal).retryStartBefore, 170);
+});
+
+test('invalid windows and arithmetic overflow cannot leave a partial first grant', () => {
+  const memory = new MemoryStore();
+  let now = 100;
+  const journal = new Journal(memory, () => now);
+  for (const invalid of [undefined, null, 0, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1]) {
+    assert.throws(() => journal.begin({ ...intent, retryForMs: invalid } as unknown as Intent), TypeError);
+  }
+  assert.throws(() => journal.begin({ ...intent, recovery: 'manual' } as unknown as Intent), TypeError);
+  now = Number.MAX_SAFE_INTEGER - 2;
+  assert.throws(() => journal.begin({ ...intent, retryForMs: 3 }, 1), TypeError);
+  now = 0;
+  const valid = acquire(journal, { ...intent, retryForMs: Number.MAX_SAFE_INTEGER }, 1);
+  assert.equal(valid.retry, false);
+  assert.equal(valid.retryStartBefore, Number.MAX_SAFE_INTEGER);
+});
+
+test('corrupt v2 retry metadata stops reads before authorization and leaves the connection usable', () => {
+  const directory = temporaryDirectory();
+  const path = join(directory, 'journal.sqlite');
+  const store = new SqliteStore(path);
+  const raw = new DatabaseSync(path);
+  let now = 100;
+  const journal = new Journal(store, () => now);
+  try {
+    const first = acquire(journal);
+    const select = raw.prepare('SELECT entry FROM tool_journal WHERE id = ?');
+    const replace = raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?');
+    const original = String(select.get(first.lease.id)!.entry);
+    const cases: Array<[string, (entry: Record<string, unknown>) => void]> = [
+      ...['firstAcquiredAt', 'retryForMs', 'retryStartBefore'].map(field =>
+        [`missing ${field}`, (entry: Record<string, unknown>) => { delete entry[field]; }] as [string, (entry: Record<string, unknown>) => void]),
+      ...['firstAcquiredAt', 'retryForMs', 'retryStartBefore'].flatMap(field =>
+        [-1, 1.5, '100', Number.MAX_SAFE_INTEGER + 1].map(value =>
+          [`${field}=${value}`, (entry: Record<string, unknown>) => { entry[field] = value; }] as [string, (entry: Record<string, unknown>) => void])),
+      ['zero window', entry => { entry.retryForMs = 0; entry.retryStartBefore = 100; }],
+      ['inconsistent cutoff', entry => { entry.retryStartBefore = 121; }],
+      ['lease before first acquisition', entry => { entry.leaseUntil = 99; }],
+      ['lease equal to first acquisition', entry => { entry.leaseUntil = 100; }],
+      ['overflowing sum', entry => {
+        entry.firstAcquiredAt = Number.MAX_SAFE_INTEGER - 5;
+        entry.retryStartBefore = Number.MAX_SAFE_INTEGER - 5 + 20;
+      }],
+      ['manual with bounded window', entry => { entry.recovery = 'manual'; }],
+      ['manual with unknown first and known window', entry => { entry.recovery = 'manual'; entry.firstAcquiredAt = null; }],
+      ['known first with unknown window', entry => { entry.retryForMs = null; entry.retryStartBefore = null; }],
+      ['unknown first with known window', entry => { entry.firstAcquiredAt = null; }],
+      ['missing cutoff with known first and duration', entry => { entry.retryStartBefore = null; }],
+      ['unknown first and duration with known cutoff', entry => { entry.firstAcquiredAt = null; entry.retryForMs = null; }],
+    ];
+    for (const [name, corrupt] of cases) {
+      const entry = JSON.parse(original) as Record<string, unknown>;
+      corrupt(entry);
+      replace.run(JSON.stringify(entry), first.lease.id);
+      // Keep version 2: the write-version guard is not a record validator.
+      assert.equal(JSON.parse(String(select.get(first.lease.id)!.entry)).version, 2);
+      let callbackInvoked = false;
+      assert.throws(() => store.transact(first.lease.id, () => {
+        callbackInvoked = true;
+        return { value: 'grant' };
+      }), /Corrupt journal entry/, name);
+      assert.equal(callbackInvoked, false, `${name}: storage exposed corrupt state`);
+      assert.throws(() => journal.begin(intent), /Corrupt journal entry/, name);
+      replace.run(original, first.lease.id);
+      assert.deepEqual(journal.begin(intent), { kind: 'busy', leaseUntil: 105 }, name);
+    }
+    now = 105;
+    const recovered = acquire(journal);
+    assert.equal(recovered.retry, true);
+    assert.equal(recovered.retryStartBefore, 120);
+  } finally {
+    raw.close();
+    store.close();
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+interface LegacyEntry {
+  version: 1;
+  id: string;
+  fingerprint: string;
+  recovery: 'manual' | 'idempotent';
+  state: 'pending' | 'completed' | 'indeterminate';
+  epoch: number;
+  executor: string;
+  leaseUntil: number;
+  result: string | null;
+}
+
+function legacyEntry(key: string, recovery: LegacyEntry['recovery'], state: LegacyEntry['state'] = 'pending'): LegacyEntry {
+  // Frozen v1 wire format. These simple JSON values have a known byte encoding;
+  // compatibility fixtures deliberately do not call the current serializer.
+  const digest = (text: string) => createHash('sha256').update(text).digest('hex');
+  return {
+    version: 1, id: digest(JSON.stringify(['legacy-window', key])),
+    fingerprint: digest(JSON.stringify(['append', { units: 7 }, recovery])),
+    recovery, state, epoch: 4, executor: `legacy-${key}`, leaseUntil: 110,
+    result: state === 'completed' ? '{"receipt":1}' : null,
+  };
+}
+
+function legacyIntent(key: string, retryForMs = 20): Intent {
+  return { scope: 'legacy-window', key, tool: 'append', input: { units: 7 }, recovery: 'idempotent', retryForMs };
+}
+
+function withLegacyDatabase(entries: LegacyEntry[], run: (path: string, raw: DatabaseSync) => void): void {
+  const directory = temporaryDirectory();
+  const path = join(directory, 'journal.sqlite');
+  const raw = new DatabaseSync(path);
+  try {
+    raw.exec('CREATE TABLE journal_meta (version INTEGER NOT NULL) STRICT; INSERT INTO journal_meta VALUES (1); CREATE TABLE tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT;');
+    for (const entry of entries) raw.prepare('INSERT INTO tool_journal VALUES (?, ?)').run(entry.id, JSON.stringify(entry));
+    run(path, raw);
+  } finally { raw.close(); rmSync(directory, { recursive: true, force: true }); }
+}
+
+test('v1 migration preserves receipts and treats unknown retry retention conservatively', () => {
+  const live = legacyEntry('live', 'idempotent');
+  const expired = legacyEntry('expired', 'idempotent');
+  const completed = legacyEntry('completed', 'idempotent', 'completed');
+  const manual = legacyEntry('manual', 'manual', 'indeterminate');
+  withLegacyDatabase([live, expired, completed, manual], (path, raw) => {
+    const store = new SqliteStore(path);
+    let now = 100;
+    const journal = new Journal(store, () => now);
+    try {
+      assert.deepEqual(raw.prepare('SELECT version FROM journal_meta').all().map(row => row.version), [2]);
+      for (const row of raw.prepare('SELECT entry FROM tool_journal').all()) {
+        const migrated = JSON.parse(String(row.entry));
+        assert.equal(migrated.version, 2);
+        assert.equal(migrated.firstAcquiredAt, null);
+        assert.equal(migrated.retryForMs, null);
+        assert.equal(migrated.retryStartBefore, null);
+      }
+      assert.deepEqual(journal.begin(legacyIntent('live')), { kind: 'busy', leaseUntil: 110 });
+      const oldLease: Lease = { id: live.id, epoch: live.epoch, executor: live.executor };
+      assert.equal(journal.complete(oldLease, { receipt: 2 }).kind, 'completed');
+      now = 110;
+      assert.deepEqual(journal.begin(legacyIntent('expired', 10_000)), { kind: 'indeterminate' });
+      assert.deepEqual(journal.begin(legacyIntent('completed')), { kind: 'replay', result: { receipt: 1 } });
+      assert.deepEqual(journal.begin(legacyIntent('completed', 40)), { kind: 'replay', result: { receipt: 1 } });
+      assert.deepEqual(journal.begin(legacyIntent('live')), { kind: 'replay', result: { receipt: 2 } });
+      const manualIntent: Intent = { scope: 'legacy-window', key: 'manual', tool: 'append', input: { units: 7 }, recovery: 'manual' };
+      assert.deepEqual(journal.begin(manualIntent), { kind: 'indeterminate' });
+      assert.equal(journal.settle(legacyIntent('expired'), { receipt: 3 }), 'settled');
+    } finally { store.close(); }
+    const reopened = new SqliteStore(path);
+    try {
+      assert.deepEqual(new Journal(reopened, () => 1_000).begin(legacyIntent('completed')), { kind: 'replay', result: { receipt: 1 } });
+    } finally { reopened.close(); }
+  });
+});
+
+test('a malformed v1 row rolls back every migrated row, schema version, and trigger', () => {
+  const good = legacyEntry('good', 'idempotent');
+  const broken = legacyEntry('broken', 'manual');
+  withLegacyDatabase([good, broken], (path, raw) => {
+    raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?').run(JSON.stringify({ ...broken, extra: 'not-a-v1-field' }), broken.id);
+    const before = raw.prepare('SELECT id, entry FROM tool_journal ORDER BY id').all();
+    assert.throws(() => new SqliteStore(path), /Corrupt|[Mm]igrat|[Ll]egacy/);
+    assert.deepEqual(raw.prepare('SELECT version FROM journal_meta').all().map(row => row.version), [1]);
+    assert.deepEqual(raw.prepare('SELECT id, entry FROM tool_journal ORDER BY id').all(), before);
+    assert.deepEqual(raw.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'").all(), []);
+    raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?').run(JSON.stringify(broken), broken.id);
+    const repaired = new SqliteStore(path);
+    try { assert.deepEqual(raw.prepare('SELECT version FROM journal_meta').all().map(row => row.version), [2]); }
+    finally { repaired.close(); }
+  });
+});
+
+test('failure after the migration updates records rolls back records and schema together', () => {
+  const pending = legacyEntry('pending', 'idempotent');
+  const completed = legacyEntry('completed', 'manual', 'completed');
+  withLegacyDatabase([pending, completed], (path, raw) => {
+    const before = raw.prepare('SELECT id, entry FROM tool_journal ORDER BY id').all();
+    raw.exec(`CREATE TRIGGER test_fail_migration BEFORE UPDATE ON journal_meta
+      WHEN NEW.version = 2 BEGIN
+        SELECT CASE WHEN NOT EXISTS (
+          SELECT 1 FROM tool_journal WHERE json_extract(entry, '$.version') IS NOT 2
+        ) THEN RAISE(ABORT, 'injected failure after record update')
+        ELSE RAISE(ABORT, 'metadata update attempted before records') END;
+      END;`);
+    assert.throws(() => new SqliteStore(path), /injected failure after record update/);
+    assert.deepEqual(raw.prepare('SELECT id, entry FROM tool_journal ORDER BY id').all(), before);
+    assert.deepEqual(raw.prepare('SELECT version FROM journal_meta').all().map(row => row.version), [1]);
+    assert.deepEqual(raw.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'").all().map(row => row.name), ['test_fail_migration']);
+    raw.exec('DROP TRIGGER test_fail_migration');
+    const recovered = new SqliteStore(path);
+    try {
+      assert.deepEqual(raw.prepare('SELECT version FROM journal_meta').all().map(row => row.version), [2]);
+      for (const row of raw.prepare('SELECT entry FROM tool_journal').all()) {
+        assert.equal(JSON.parse(String(row.entry)).version, 2);
+      }
+      const value: Intent = { scope: 'legacy-window', key: 'completed', tool: 'append', input: { units: 7 }, recovery: 'manual' };
+      assert.deepEqual(new Journal(recovered, () => 120).begin(value), { kind: 'replay', result: { receipt: 1 } });
+    } finally { recovered.close(); }
+  });
+});
+
+test('migration normalizes legacy duplicate JSON members with the same parser used for validation', () => {
+  const completed = legacyEntry('duplicate-version', 'idempotent', 'completed');
+  withLegacyDatabase([completed], (path, raw) => {
+    // v1's JSON.parse reads the last member. SQLite json_set would change the
+    // first one and leave a version-1 member behind after an apparent migration.
+    raw.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?')
+      .run('{"version":9,' + JSON.stringify(completed).slice(1), completed.id);
+    const store = new SqliteStore(path);
+    try {
+      const encoded = String(raw.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(completed.id)!.entry);
+      assert.equal((encoded.match(/"version":/g) ?? []).length, 1);
+      assert.equal(JSON.parse(encoded).version, 2);
+      assert.deepEqual(new Journal(store, () => 1_000).begin(legacyIntent('duplicate-version')),
+        { kind: 'replay', result: { receipt: 1 } });
+    } finally { store.close(); }
+  });
+});
+
+test('migration does not skip an empty corrupted identity during keyset iteration', () => {
+  const good = legacyEntry('valid', 'idempotent');
+  withLegacyDatabase([good], (path, raw) => {
+    raw.prepare('INSERT INTO tool_journal VALUES (?, ?)').run('', JSON.stringify({ ...good, id: '' }));
+    const before = raw.prepare('SELECT id, entry FROM tool_journal ORDER BY id').all();
+    assert.throws(() => new SqliteStore(path), /Corrupt journal entry/);
+    assert.deepEqual(raw.prepare('SELECT id, entry FROM tool_journal ORDER BY id').all(), before);
+    assert.equal(raw.prepare('SELECT version FROM journal_meta').get()!.version, 1);
+  });
+});
+
+test('already-open legacy connections cannot insert or restore v1-format rows after migration', () => {
+  const existing = legacyEntry('existing', 'idempotent');
+  withLegacyDatabase([existing], (path, legacyConnection) => {
+    // Prepare the statements while the legacy database is still version 1.
+    const oldInsert = legacyConnection.prepare('INSERT INTO tool_journal VALUES (?, ?)');
+    const oldUpdate = legacyConnection.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?');
+    const store = new SqliteStore(path);
+    try {
+      const another = legacyEntry('another', 'idempotent');
+      assert.throws(() => oldInsert.run(another.id, JSON.stringify(another)));
+      assert.throws(() => oldUpdate.run(JSON.stringify(existing), existing.id));
+      assert.equal(legacyConnection.prepare('SELECT count(*) AS count FROM tool_journal').get()!.count, 1);
+      const persisted = JSON.parse(String(legacyConnection.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(existing.id)!.entry));
+      assert.equal(persisted.version, 2);
+      // The old constructor's version-1 precondition is no longer satisfied.
+      assert.notEqual(legacyConnection.prepare('SELECT version FROM journal_meta').get()!.version, 1);
+    } finally { store.close(); }
+  });
+});
+
+class ExpiringProvider {
+  calls = 0;
+  effects = 0;
+  private readonly receipts = new Map<string, { until: number; receipt: number }>();
+  constructor(private readonly retentionMs: number) {}
+  send(key: string, now: number): { receipt: number } {
+    this.calls++;
+    const prior = this.receipts.get(key);
+    if (prior && now < prior.until) return { receipt: prior.receipt };
+    const receipt = ++this.effects;
+    this.receipts.set(key, { until: now + this.retentionMs, receipt });
+    return { receipt };
+  }
+}
+
+test('expired admission refuses a new request even if the provider has forgotten the key', () => {
+  withRuntime('sqlite', runtime => {
+    const provider = new ExpiringProvider(20);
+    const first = acquire(runtime.journal);
+    provider.send(first.lease.id, runtime.now); // The receipt never reaches the journal.
+    runtime.now = 120;
+    runtime.reopen();
+    const recovery = runtime.journal.begin(intent);
+    if (recovery.kind === 'acquired') provider.send(recovery.lease.id, runtime.now);
+    assert.deepEqual(recovery, { kind: 'indeterminate' });
+    assert.equal(provider.calls, 1);
+    assert.equal(provider.effects, 1);
+  });
+});
+
+test('counterexample: admission before the cutoff cannot stop a delayed request reaching an expired provider key', () => {
+  withRuntime('sqlite', runtime => {
+    const provider = new ExpiringProvider(20);
+    const first = acquire(runtime.journal);
+    provider.send(first.lease.id, 100);
+    runtime.now = 119;
+    const retry = acquire(runtime.journal);
+    assert.equal(retry.retryStartBefore, 120);
+    // The executor pauses, or its request queues after its final local check.
+    // Even a valid lease and stable key cannot enforce the remote arrival time.
+    runtime.now = 121;
+    const receipt = provider.send(retry.lease.id, runtime.now);
+    assert.equal(provider.effects, 2);
+    assert.equal(runtime.journal.complete(retry.lease, receipt).kind, 'completed');
+    assert.equal(provider.calls, 2);
+  });
+});

--- a/tests/retry-window.test.ts
+++ b/tests/retry-window.test.ts
@@ -275,6 +275,29 @@ test('v1 migration preserves receipts and treats unknown retry retention conserv
   });
 });
 
+for (const [name, damage] of [
+  ['missing records table', 'DROP TABLE tool_journal'],
+  ['missing version table', 'DROP TABLE journal_meta'],
+  ['missing version row', 'DELETE FROM journal_meta'],
+  ['ambiguous version rows', 'INSERT INTO journal_meta VALUES (1), (1)'],
+] as const) {
+  test(`opening a journal rejects ${name} without reconstructing lost state`, () => {
+    const completed = legacyEntry('existing-receipt', 'idempotent', 'completed');
+    withLegacyDatabase([completed], (path, raw) => {
+      raw.exec(damage);
+      const schema = raw.prepare("SELECT name, sql FROM sqlite_master WHERE name IN ('journal_meta', 'tool_journal') ORDER BY name");
+      const before = schema.all();
+      assert.throws(() => new SqliteStore(path), /Unsupported journal schema/);
+      assert.deepEqual(schema.all(), before);
+      if (name !== 'missing records table') {
+        assert.equal(raw.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(completed.id)!.entry, JSON.stringify(completed));
+      }
+      if (name === 'missing version row') assert.equal(raw.prepare('SELECT count(*) AS count FROM journal_meta').get()!.count, 0);
+      if (name === 'ambiguous version rows') assert.equal(raw.prepare('SELECT count(*) AS count FROM journal_meta').get()!.count, 3);
+    });
+  });
+}
+
 test('a malformed v1 row rolls back every migrated row, schema version, and trigger', () => {
   const good = legacyEntry('good', 'idempotent');
   const broken = legacyEntry('broken', 'manual');


### PR DESCRIPTION
An idempotent provider can eventually discard an old request key. v0.1 required integrators to cover the entire retry horizon but could continue granting retries indefinitely. v0.2 requires a finite `retryForMs`, persists its first-acquisition anchor, and refuses new retry leases at or after the fixed cutoff. Retrying, renewing and reopening cannot refresh the window. A changed known window conflicts with the recorded policy.

Retry admission remains separate from ownership: an active lease can renew or complete after admission closes, and confirmed receipts remain replayable. Once ownership expires after admission closes, the operation becomes indeterminate and requires external reconciliation. A delayed request can still reach a provider after it discards its key; a regression deliberately reproduces this counterexample rather than implying that a local cutoff guarantees remote execution timing.

This is an API and storage upgrade to 0.2.0. SQLite schema/record v2 migrates v1 rows in one transaction using bounded keyset iteration and the same JSON parser/encoder used for validation. Unknown historical timestamps remain null. Legacy completed receipts replay; legacy pending idempotent operations may finish under a live lease but receive no fresh retry window. Migration failures roll back rows and metadata. Metadata and write-version guards reject old clients; operators must still stop old executors and take a consistent backup before upgrading. Database downgrade is unsupported.

Tests cover exact cutoff boundaries, renewal and receipt handling, 26 malformed window cases, legacy receipt preservation, failures before and after migration writes, duplicate JSON members, empty corrupt identities, already-open old connections and an expiring synthetic provider. The independent model adds fixed admission windows and required boundary coverage. A separate local compatibility experiment used the actual v0.1.2 release archive to verify old-client rejection and new-client availability.

Opening a partial database refuses missing tables or missing/ambiguous schema metadata instead of reconstructing an empty journal. Metadata reads are bounded. Four regression cases verify that rejected opens leave the surviving records and schema unchanged.

Validation: 116 core tests, eight targeted mutation checks, public-tree checks and a real installed-package TypeScript consumer passed locally on Node 24.15.0 with TypeScript 7.0.2. The LangGraph example passed seven integration tests and its demo through the public package. The existing six OS/Node checks are the merge gate. Framework dependencies stay isolated from the zero-runtime-dependency core; routine npm updates are limited to minor/patch versions without suppressing security updates.
