### PR TITLE
Bound SQLite reads and replay completed receipts without a writer lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,16 @@ jobs:
       - run: npm run demo
         working-directory: integrations/langgraph
       - run: npm run benchmark
+      - run: npm run benchmark:runtime
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: crash-matrix-${{ matrix.os }}-node-${{ matrix.node }}
           path: artifacts/crash-matrix.json
+          if-no-files-found: error
+          retention-days: 30
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: runtime-cost-${{ matrix.os }}-node-${{ matrix.node }}
+          path: artifacts/runtime-cost.json
           if-no-files-found: error
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.0
+
+- Replay completed receipts through an optional validated Store snapshot. SQLite
+  readers no longer need the writer lock for that path; all execution grants
+  still read and commit inside the existing write transaction.
+- Bound SQLite values before the native wrapper returns them to JavaScript,
+  including legacy migration records and identities. Preserve valid UTF-16
+  databases and the precise UTF-8 receipt limit. Reject noninteger schema metadata.
+- Reuse per-connection read/write statements and expose an independent runtime
+  experiment for operation latency, contention, event-loop delay and file growth.
+- Document lock errors, worker isolation, backup freshness and safe recovery.
+  The SQLite busy timeout is configuration, not a total wall-clock deadline.
+- Keep storage schema v2. Existing v0.2 records need no migration; custom stores
+  without the optional read method retain their transactional behavior.
+
 ## 0.2.0
 
 - Require an explicit finite retry admission window for idempotent operations.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ library archive through the public API. No model key or external service is need
 
 ## Use the journal
 
+Download the `.tgz` from the [v0.3.0 release](https://github.com/RaycarlLei/tool-journal/releases/tag/v0.3.0)
+and install it in your application:
+
+```sh
+npm install ./raycarllei-tool-journal-0.3.0.tgz
+```
+
+The archive contains compiled JavaScript and TypeScript declarations. To build it
+yourself, run `npm pack` in this checkout. The package has no install-time hooks or
+runtime dependencies; the crash experiments and framework example stay in the
+source repository.
+
 ```ts
 import { Journal, SqliteStore } from '@raycarllei/tool-journal';
 
@@ -94,7 +106,7 @@ store.close();
 ```
 
 The API example illustrates an integration; `downstream` is not supplied by this
-package. The clone-and-run demo above is self-contained. v0.2 is distributed as
+package. The clone-and-run demo above is self-contained. v0.3 is distributed as
 source and a release archive; no npm registry publication is assumed.
 
 `begin` binds a scope/key to the tool, canonical input and recovery policy.
@@ -113,6 +125,11 @@ The cutoff governs journal authorization, not arrival at the downstream service.
 An executor paused before sending, or a delayed request, can still arrive after a
 provider deletes its key. Client timeouts do not establish server-side cancellation.
 
+In the built-in stores, `begin` can replay a committed receipt through a validated
+read snapshot without waiting for a SQLite writer lock. New execution still needs
+the write transaction; an absent or pending snapshot never grants a lease. See the
+[operating guide](docs/operations.md) and [runtime measurements](docs/runtime-performance.md).
+
 ## Guarantees and limits
 
 - SQLite transactions serialize claims from processes sharing one local database.
@@ -125,7 +142,7 @@ provider deletes its key. Client timeouts do not establish server-side cancellat
 - No cross-service exactly-once guarantee. No database GC, distributed clock,
   scheduler, authentication, model SDK or live trading integration.
 - Node's built-in SQLite API is experimental in Node 24; the adapter is synchronous.
-  This is a v0.2 reference implementation, not a production SLA.
+  This is a v0.3 reference implementation, not a production SLA.
 
 Read the [failure contract](docs/contract.md) before integrating.
 
@@ -142,10 +159,11 @@ Read the [failure contract](docs/contract.md) before integrating.
 ```sh
 npm run check           # tests, targeted mutations, public-tree and package checks
 npm run benchmark       # 100 controlled cases; writes artifacts/crash-matrix.json
+npm run benchmark:runtime # operation latency, lock waits and event-loop probes
 npm pack               # compiled library + docs; no fixtures or local databases
 ```
 
-The targeted mutation check removes eight safeguards, one at a time, and requires
+The targeted mutation check removes nine safeguards, one at a time, and requires
 an assertion failure for each. It is not a whole-project mutation score. The package
 check installs the real archive offline in a fresh project, exercises SQLite reopen
 through the public exports, and compiles a TypeScript consumer. CI runs on Linux,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,8 @@ are plaintext; return only the receipt fields needed for recovery.
 The JSON encoder rejects proxies and accessors without invoking them and stops at
 its output budget. Callers still need admission control and request/body limits
 before parsing untrusted input. A local synchronous lock wait can block the event
-loop; the five-second busy timeout is a bound, not an availability guarantee.
+loop. SQLite's busy timeout is configured to 5,000 ms; total call duration can
+exceed it. Completed receipt reads avoid the writer lock, but remain synchronous.
 
 For a suspected vulnerability, use this repository's GitHub private vulnerability
 reporting feature when enabled. Do not post credentials, private databases or user
@@ -22,6 +23,6 @@ An admission cutoff limits new journal leases, not the provider's execution time
 Old executors, delayed requests, a reused pre-journal key and an unstable clock can
 violate an integrator's retention assumptions. See [retry admission](docs/retry-admission.md).
 
-Only the latest 0.2.x release is maintained at this stage. The database upgrade is
+Only the latest 0.3.x release is maintained at this stage. The v1 database upgrade is
 forward-only; stop old executors and back up before migration. No security audit or
 production certification is claimed.

--- a/benchmarks/runtime-process.ts
+++ b/benchmarks/runtime-process.ts
@@ -9,6 +9,16 @@ export type Workload = 'execute' | 'replay';
 export interface Failure { code: string; sqliteCode: number | null }
 export interface Sample { sequence: number; elapsedMs: number; outcome: string; error: Failure | null }
 export interface Cpu { user: number; system: number }
+export const runtimeLimits = { workerMs: 90_000, fixtureMs: 240_000 } as const;
+
+class RuntimeDeadlineError extends Error {
+  readonly code: string;
+  constructor(scope: 'worker' | 'fixture') {
+    super(`Runtime ${scope} deadline exceeded`);
+    this.code = scope === 'worker' ? 'ERR_RUNTIME_WORKER_DEADLINE' : 'ERR_RUNTIME_FIXTURE_DEADLINE';
+  }
+}
+
 export type Configuration =
   | { kind: 'configure'; role: 'batch'; database: string; workload: Workload; worker: number; samples: number; warmup: number }
   | { kind: 'configure'; role: 'holder'; database: string; holdMs: number };
@@ -55,10 +65,10 @@ export class RuntimeChild {
   private ended = false;
   readonly closed: Promise<void>;
 
-  constructor(arguments_: string[] = [fileURLToPath(new URL('./runtime-worker.js', import.meta.url))], timeoutMs = 25_000) {
-    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) throw new TypeError('Invalid worker deadline');
+  constructor(arguments_: string[] = [fileURLToPath(new URL('./runtime-worker.js', import.meta.url))], timeoutMs: number = runtimeLimits.workerMs) {
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 120_000) throw new TypeError('Invalid worker deadline');
     this.child = spawn(process.execPath, arguments_, { stdio: ['ignore', 'ignore', 'ignore', 'ipc'], windowsHide: true });
-    const deadline = setTimeout(() => this.fail(new Error('Runtime worker deadline exceeded')), timeoutMs);
+    const deadline = setTimeout(() => this.fail(new RuntimeDeadlineError('worker')), timeoutMs);
     this.child.on('error', () => this.fail(new Error('Runtime worker could not start')));
     this.child.on('message', raw => {
       const value = raw as Reply;
@@ -111,8 +121,11 @@ export class RuntimeChild {
     await this.closed;
     if (this.failure) throw this.failure;
   }
-  async stop(): Promise<void> {
-    if (!this.ended) this.child.kill('SIGKILL');
+  async stop(error?: Error): Promise<void> {
+    if (!this.ended) {
+      if (error) this.fail(error);
+      else this.child.kill('SIGKILL');
+    }
     await this.closed;
   }
 }
@@ -122,13 +135,13 @@ export class RuntimeFixture {
   readonly directory = realpathSync(mkdtempSync(join(this.root, 'journal-runtime-')));
   private readonly workers: RuntimeChild[] = [];
   private readonly deadline: NodeJS.Timeout;
-  private readonly expiresAt = performance.now() + 60_000;
+  private readonly expiresAt = performance.now() + runtimeLimits.fixtureMs;
   private expired = false;
   constructor() {
     this.deadline = setTimeout(() => {
       this.expired = true;
-      for (const worker of this.workers) void worker.stop();
-    }, 60_000);
+      for (const worker of this.workers) void worker.stop(new RuntimeDeadlineError('fixture'));
+    }, runtimeLimits.fixtureMs);
   }
   worker(arguments_?: string[], timeoutMs?: number): RuntimeChild {
     this.checkDeadline();
@@ -137,7 +150,7 @@ export class RuntimeFixture {
     return child;
   }
   checkDeadline(): void {
-    if (this.expired || performance.now() >= this.expiresAt) throw new Error('Runtime fixture deadline exceeded');
+    if (this.expired || performance.now() >= this.expiresAt) throw new RuntimeDeadlineError('fixture');
   }
   async close(): Promise<void> {
     clearTimeout(this.deadline);

--- a/benchmarks/runtime-process.ts
+++ b/benchmarks/runtime-process.ts
@@ -1,0 +1,151 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+
+export type Workload = 'execute' | 'replay';
+export interface Failure { code: string; sqliteCode: number | null }
+export interface Sample { sequence: number; elapsedMs: number; outcome: string; error: Failure | null }
+export interface Cpu { user: number; system: number }
+export type Configuration =
+  | { kind: 'configure'; role: 'batch'; database: string; workload: Workload; worker: number; samples: number; warmup: number }
+  | { kind: 'configure'; role: 'holder'; database: string; holdMs: number };
+export type Reply =
+  | { kind: 'ready' }
+  | { kind: 'locked' }
+  | { kind: 'released'; heldMs: number }
+  | { kind: 'results'; worker: number; elapsedMs: number; cpu: Cpu; samples: Sample[] }
+  | { kind: 'failed'; error: Failure };
+
+export function failure(error: unknown): Failure {
+  const record = typeof error === 'object' && error !== null ? error as Record<string, unknown> : {};
+  // Do not serialize arbitrary exception messages: they may contain local paths.
+  return { code: typeof record.code === 'string' && /^[A-Z_0-9]{1,64}$/.test(record.code) ? record.code : 'UNEXPECTED',
+    sqliteCode: typeof record.errcode === 'number' ? record.errcode : null };
+}
+function isFailure(value: unknown): value is Failure {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.code === 'string' && /^[A-Z_0-9]{1,64}$/.test(record.code) &&
+    (record.sqliteCode === null || (Number.isSafeInteger(record.sqliteCode) && Number(record.sqliteCode) >= 0));
+}
+export const milliseconds = (value: number): number => Math.round(value * 1_000) / 1_000;
+export function statistics(values: number[]) {
+  if (values.length === 0) throw new Error('Cannot summarize an empty sample');
+  const sorted = [...values].sort((a, b) => a - b);
+  const at = (fraction: number) => sorted[Math.ceil(sorted.length * fraction) - 1]!;
+  return { n: sorted.length, p50: at(0.5), p95: at(0.95), p99: at(0.99), max: sorted.at(-1)! };
+}
+export function fileBytes(database: string) {
+  const size = (suffix: string): number => {
+    try { return statSync(database + suffix).size; }
+    catch (error) { if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0; throw error; }
+  };
+  return { database: size(''), wal: size('-wal'), shm: size('-shm') };
+}
+
+/** A child is not released until its IPC handles have closed, including on failure. */
+export class RuntimeChild {
+  private readonly child: ChildProcess;
+  private readonly queue: Reply[] = [];
+  private readonly waiting = new Map<string, { resolve: (value: Reply) => void; reject: (error: Error) => void }>();
+  private failure: Error | undefined;
+  private ended = false;
+  readonly closed: Promise<void>;
+
+  constructor(arguments_: string[] = [fileURLToPath(new URL('./runtime-worker.js', import.meta.url))], timeoutMs = 25_000) {
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) throw new TypeError('Invalid worker deadline');
+    this.child = spawn(process.execPath, arguments_, { stdio: ['ignore', 'ignore', 'ignore', 'ipc'], windowsHide: true });
+    const deadline = setTimeout(() => this.fail(new Error('Runtime worker deadline exceeded')), timeoutMs);
+    this.child.on('error', () => this.fail(new Error('Runtime worker could not start')));
+    this.child.on('message', raw => {
+      const value = raw as Reply;
+      if (typeof value !== 'object' || value === null || Array.isArray(value) ||
+          !['ready', 'locked', 'released', 'results', 'failed'].includes(value.kind)) {
+        this.fail(new Error('Unexpected runtime worker message'));
+      } else if (value.kind === 'failed') {
+        // IPC payloads are runtime data. Never let a malformed failure throw
+        // from the event listener and bypass child/fixture cleanup.
+        this.fail(new Error(isFailure(value.error)
+          ? `Runtime worker reported ${value.error.code}`
+          : 'Unexpected runtime worker failure message'));
+      } else {
+        const waiter = this.waiting.get(value.kind);
+        if (waiter) { this.waiting.delete(value.kind); waiter.resolve(value); }
+        else if (this.queue.length < 8) this.queue.push(value);
+        else this.fail(new Error('Too many runtime worker messages'));
+      }
+    });
+    this.closed = new Promise(resolve => this.child.once('close', code => {
+      clearTimeout(deadline);
+      this.ended = true;
+      if (code !== 0 && !this.failure) this.failure = new Error('Runtime worker exited unsuccessfully');
+      for (const waiter of this.waiting.values()) waiter.reject(this.failure ?? new Error('Runtime worker exited before its reply'));
+      this.waiting.clear();
+      resolve();
+    }));
+  }
+  private fail(error: Error): void {
+    this.failure ??= error;
+    if (!this.ended) this.child.kill('SIGKILL');
+  }
+  send(value: Configuration | { kind: 'start' | 'ack' }): void {
+    if (this.failure || this.ended) throw this.failure ?? new Error('Runtime worker is closed');
+    this.child.send(value, error => { if (error) this.fail(new Error('Runtime worker IPC failed')); });
+  }
+  receive<K extends Reply['kind']>(kind: K): Promise<Extract<Reply, { kind: K }>> {
+    const queued = this.queue.findIndex(value => value.kind === kind);
+    if (queued >= 0) return Promise.resolve(this.queue.splice(queued, 1)[0] as Extract<Reply, { kind: K }>);
+    if (this.ended) return Promise.reject(this.failure ?? new Error('Runtime worker is closed'));
+    if (this.waiting.has(kind)) throw new Error('Duplicate runtime worker waiter');
+    const promise = new Promise<Reply>((resolve, reject) => this.waiting.set(kind, { resolve, reject }));
+    // A synchronous SQLite call may postpone awaiting another already-armed reply.
+    // Observe early rejection without changing the promise delivered to the caller.
+    void promise.catch(() => {});
+    return promise as Promise<Extract<Reply, { kind: K }>>;
+  }
+  async acknowledge(): Promise<void> {
+    this.send({ kind: 'ack' });
+    await this.closed;
+    if (this.failure) throw this.failure;
+  }
+  async stop(): Promise<void> {
+    if (!this.ended) this.child.kill('SIGKILL');
+    await this.closed;
+  }
+}
+
+export class RuntimeFixture {
+  private readonly root = realpathSync(tmpdir());
+  readonly directory = realpathSync(mkdtempSync(join(this.root, 'journal-runtime-')));
+  private readonly workers: RuntimeChild[] = [];
+  private readonly deadline: NodeJS.Timeout;
+  private readonly expiresAt = performance.now() + 60_000;
+  private expired = false;
+  constructor() {
+    this.deadline = setTimeout(() => {
+      this.expired = true;
+      for (const worker of this.workers) void worker.stop();
+    }, 60_000);
+  }
+  worker(arguments_?: string[], timeoutMs?: number): RuntimeChild {
+    this.checkDeadline();
+    const child = new RuntimeChild(arguments_, timeoutMs);
+    this.workers.push(child);
+    return child;
+  }
+  checkDeadline(): void {
+    if (this.expired || performance.now() >= this.expiresAt) throw new Error('Runtime fixture deadline exceeded');
+  }
+  async close(): Promise<void> {
+    clearTimeout(this.deadline);
+    await Promise.all(this.workers.map(worker => worker.stop()));
+    const resolved = realpathSync(this.directory);
+    if (resolved !== this.directory || dirname(resolved) !== this.root || !basename(resolved).startsWith('journal-runtime-')) {
+      throw new Error('Runtime fixture no longer resolves to its own temporary directory');
+    }
+    rmSync(resolved, { recursive: true, force: true });
+  }
+}

--- a/benchmarks/runtime-worker.ts
+++ b/benchmarks/runtime-worker.ts
@@ -1,0 +1,87 @@
+import { DatabaseSync } from 'node:sqlite';
+import { performance } from 'node:perf_hooks';
+import { Journal, SqliteStore, type Intent } from '../src/index.js';
+import { failure, milliseconds, type Configuration, type Reply, type Sample } from './runtime-process.js';
+
+function send(value: Reply): void {
+  process.send!(value, error => { if (error) process.exitCode = 1; });
+}
+function command(kind: 'start' | 'ack'): Promise<void> {
+  return new Promise((resolve, reject) => process.once('message', value => {
+    if (typeof value === 'object' && value !== null && 'kind' in value && value.kind === kind) resolve();
+    else reject(new Error('Unexpected parent command'));
+  }));
+}
+const value = (key: string): Intent => ({ scope: 'runtime-benchmark', key, tool: 'synthetic-append', input: { units: 7 }, recovery: 'idempotent', retryForMs: 120_000 });
+
+async function run(config: Configuration): Promise<void> {
+  if (!config || config.kind !== 'configure' || typeof config.database !== 'string') throw new Error('Invalid worker configuration');
+  if (config.role === 'holder') {
+    if (!Number.isSafeInteger(config.holdMs) || config.holdMs < 1 || config.holdMs > 6_000) throw new Error('Invalid hold duration');
+    const db = new DatabaseSync(config.database, { timeout: 5_000 });
+    try {
+      const start = command('start');
+      send({ kind: 'ready' });
+      await start;
+      db.exec('BEGIN IMMEDIATE');
+      const began = performance.now();
+      send({ kind: 'locked' });
+      await new Promise(resolve => setTimeout(resolve, config.holdMs));
+      db.exec('COMMIT');
+      const ack = command('ack');
+      send({ kind: 'released', heldMs: milliseconds(performance.now() - began) });
+      await ack;
+    } finally { db.close(); }
+    return;
+  }
+  if (config.role !== 'batch' || !['execute', 'replay'].includes(config.workload) ||
+      !Number.isSafeInteger(config.samples) || config.samples < 1 || config.samples > 5_000 ||
+      !Number.isSafeInteger(config.warmup) || config.warmup < 0 || config.warmup > 500 ||
+      !Number.isSafeInteger(config.worker) || config.worker < 0 || config.worker > 3) throw new Error('Invalid batch configuration');
+  const store = new SqliteStore(config.database);
+  try {
+    const journal = new Journal(store);
+    const operate = (key: string): string => {
+      const begun = journal.begin(value(config.workload === 'replay' ? 'receipt' : key));
+      if (config.workload === 'replay') {
+        if (begun.kind !== 'replay') throw new Error('Expected completed receipt');
+        return begun.kind;
+      }
+      if (begun.kind !== 'acquired' || begun.retry) throw new Error('Expected first acquisition');
+      const complete = journal.complete(begun.lease, { receipt: 1 });
+      if (complete.kind !== 'completed') throw new Error('Expected completion');
+      return complete.kind;
+    };
+    for (let i = 0; i < config.warmup; i++) operate(`warm-${config.worker}-${i}`);
+    const start = command('start');
+    send({ kind: 'ready' });
+    await start;
+    const samples: Sample[] = [];
+    const cpuStart = process.cpuUsage();
+    const began = performance.now();
+    for (let i = 0; i < config.samples; i++) {
+      const started = performance.now();
+      let outcome = 'error', error = null;
+      try { outcome = operate(`sample-${config.worker}-${i}`); }
+      catch (caught) { error = failure(caught); }
+      samples.push({ sequence: i, elapsedMs: milliseconds(performance.now() - started), outcome, error });
+    }
+    const elapsedMs = milliseconds(performance.now() - began);
+    const cpu = process.cpuUsage(cpuStart);
+    const ack = command('ack');
+    send({ kind: 'results', worker: config.worker, elapsedMs, cpu, samples });
+    await ack;
+  } finally { store.close(); }
+}
+
+if (!process.send || process.argv.length !== 2) {
+  console.error('Runtime worker requires its benchmark parent');
+  process.exitCode = 1;
+} else {
+  process.once('message', config => {
+    void run(config as Configuration).then(() => process.disconnect()).catch(error => {
+      process.exitCode = 1;
+      process.send!({ kind: 'failed', error: failure(error) }, () => process.disconnect());
+    });
+  });
+}

--- a/benchmarks/runtime.ts
+++ b/benchmarks/runtime.ts
@@ -8,7 +8,7 @@ import { performance } from 'node:perf_hooks';
 import { DatabaseSync } from 'node:sqlite';
 import { fileURLToPath } from 'node:url';
 import { Journal, SqliteStore, type Intent } from '../src/index.js';
-import { RuntimeFixture, failure, fileBytes, milliseconds, statistics, type Failure, type Workload } from './runtime-process.js';
+import { RuntimeFixture, failure, fileBytes, milliseconds, statistics, runtimeLimits, type Failure, type Workload } from './runtime-process.js';
 
 const value = (key: string): Intent => ({ scope: 'runtime-benchmark', key, tool: 'synthetic-append', input: { units: 7 }, recovery: 'idempotent', retryForMs: 120_000 });
 function seed(journal: Journal): void {
@@ -155,7 +155,7 @@ export async function runtimeBenchmark(repository: string) {
         batch: 'Parent start broadcast to all replies, including IPC; fixed aggregate work across process counts.',
         cpu: 'process.cpuUsage microseconds per measured batch/call, summed across execution processes.',
         quantiles: 'Nearest rank: ceil(p*n), no interpolation or removal of error samples.' },
-      limits: { workerMs: 25_000, fixtureMs: 60_000 }, elapsedMs: milliseconds(performance.now() - started),
+      limits: runtimeLimits, elapsedMs: milliseconds(performance.now() - started),
       batches, locks: { idleTimers, idleTimerMs: statistics(idleTimers), samples: locked,
         groups: ['replay', 'begin'].flatMap(target => [250, 6_000].map(holdMs => {
           const samples = locked.filter(sample => sample.target === target && sample.requestedHoldMs === holdMs);

--- a/benchmarks/runtime.ts
+++ b/benchmarks/runtime.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpus, release, totalmem } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { DatabaseSync } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
+import { Journal, SqliteStore, type Intent } from '../src/index.js';
+import { RuntimeFixture, failure, fileBytes, milliseconds, statistics, type Failure, type Workload } from './runtime-process.js';
+
+const value = (key: string): Intent => ({ scope: 'runtime-benchmark', key, tool: 'synthetic-append', input: { units: 7 }, recovery: 'idempotent', retryForMs: 120_000 });
+function seed(journal: Journal): void {
+  const begun = journal.begin(value('receipt'));
+  assert.equal(begun.kind, 'acquired');
+  if (begun.kind !== 'acquired') throw new Error('Expected fresh fixture');
+  assert.equal(journal.complete(begun.lease, { receipt: 1 }).kind, 'completed');
+}
+
+export async function runBatch(fixture: RuntimeFixture, workload: Workload, processes: 1 | 4, totalSamples: number, totalWarmup: number) {
+  if (!Number.isSafeInteger(totalSamples) || totalSamples < processes || totalSamples % processes !== 0 ||
+      !Number.isSafeInteger(totalWarmup) || totalWarmup < 0 || totalWarmup % processes !== 0) throw new TypeError('Invalid aggregate work');
+  const name = `${workload}-${processes}-process`;
+  const database = join(fixture.directory, `${name}.sqlite`);
+  const anchor = new SqliteStore(database);
+  try {
+    if (workload === 'replay') seed(new Journal(anchor));
+    const workers = Array.from({ length: processes }, () => fixture.worker());
+    await Promise.all(workers.map((worker, index) => {
+      const ready = worker.receive('ready');
+      worker.send({ kind: 'configure', role: 'batch', database, workload, worker: index,
+        samples: totalSamples / processes, warmup: totalWarmup / processes });
+      return ready;
+    }));
+    const before = fileBytes(database);
+    const pending = workers.map(worker => worker.receive('results'));
+    const started = performance.now();
+    for (const worker of workers) worker.send({ kind: 'start' });
+    const results = await Promise.all(pending);
+    const elapsedMs = milliseconds(performance.now() - started);
+    const after = fileBytes(database);
+    await Promise.all(workers.map(worker => worker.acknowledge()));
+    anchor.close();
+    const samples = results.flatMap(result => result.samples);
+    assert.equal(samples.length, totalSamples);
+    const errors = samples.filter(sample => sample.error !== null).length;
+    return { name, workload, processes, totalSamples, totalWarmup, elapsedMs,
+      latencyMs: statistics(samples.map(sample => sample.elapsedMs)), errors,
+      operationsPerSecond: Math.round((samples.length - errors) * 1_000 / elapsedMs),
+      cpu: results.reduce((total, result) => ({ user: total.user + result.cpu.user, system: total.system + result.cpu.system }), { user: 0, system: 0 }),
+      storageBytes: { before, after, afterClose: fileBytes(database),
+        measuredNetGrowth: { database: after.database - before.database, wal: after.wal - before.wal, shm: after.shm - before.shm } },
+      workers: results };
+  } finally { anchor.close(); }
+}
+
+export async function runHeldLock(fixture: RuntimeFixture, target: 'replay' | 'begin', holdMs: number) {
+  const database = join(fixture.directory, `lock-${target}-${holdMs}.sqlite`);
+  const store = new SqliteStore(database);
+  try {
+    const journal = new Journal(store);
+    seed(journal);
+    const holder = fixture.worker();
+    const ready = holder.receive('ready');
+    holder.send({ kind: 'configure', role: 'holder', database, holdMs });
+    await ready;
+    const before = fileBytes(database);
+    const locked = holder.receive('locked');
+    const released = holder.receive('released');
+    holder.send({ kind: 'start' });
+    await locked;
+    const timerStarted = performance.now();
+    const probe = new Promise<number>(resolve => setTimeout(() => resolve(milliseconds(performance.now() - timerStarted)), 0));
+    const cpuStart = process.cpuUsage();
+    const started = performance.now();
+    let outcome = 'error', error: Failure | null = null;
+    try { outcome = journal.begin(value(target === 'replay' ? 'receipt' : 'new-key')).kind; }
+    catch (caught) { error = failure(caught); }
+    const elapsedMs = milliseconds(performance.now() - started);
+    const cpu = process.cpuUsage(cpuStart);
+    const timerDelayMs = await probe;
+    const release = await released;
+    await holder.acknowledge();
+    // The result is observed, not prescribed: a completed-read fast path can
+    // remove replay contention without changing the write-path measurement.
+    assert.equal(journal.begin(value('receipt')).kind, 'replay');
+    const after = fileBytes(database);
+    store.close();
+    return { target, requestedHoldMs: holdMs, actualHoldMs: release.heldMs, elapsedMs, timerDelayMs, cpu, outcome, error,
+      storageBytes: { before, after, afterClose: fileBytes(database),
+        measuredNetGrowth: { database: after.database - before.database, wal: after.wal - before.wal, shm: after.shm - before.shm } } };
+  } finally { store.close(); }
+}
+
+function source(repository: string) {
+  const digest = (path: string) => createHash('sha256').update(readFileSync(path)).digest('hex');
+  let commit: string | null = null, workingTreeDirty: boolean | null = null;
+  try {
+    const git = (...args: string[]) => execFileSync('git', args, { cwd: repository, encoding: 'utf8', timeout: 5_000, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    commit = git('rev-parse', 'HEAD');
+    workingTreeDirty = git('status', '--porcelain') !== '';
+  } catch { /* Source archives may not have Git metadata. Build hashes remain available. */ }
+  return { commit, workingTreeDirty, lockSha256: digest(join(repository, 'package-lock.json')),
+    distSha256: Object.fromEntries(['src/index', 'src/journal', 'src/record', 'src/sqlite', 'src/memory', 'src/json',
+      'benchmarks/runtime', 'benchmarks/runtime-process', 'benchmarks/runtime-worker'].map(name => [name, digest(join(repository, 'dist', `${name}.js`))])) };
+}
+
+class BenchmarkFailure extends Error {
+  constructor(phase: string, readonly code: string, cause: unknown) {
+    super(`Runtime benchmark failed during ${phase} (${code})`, { cause });
+  }
+}
+
+export async function runtimeBenchmark(repository: string) {
+  const initialSource = source(repository);
+  const fixture = new RuntimeFixture();
+  const started = performance.now();
+  let phase = 'environment';
+  try {
+    const db = new DatabaseSync(':memory:');
+    let sqliteVersion: unknown, pageBytes: unknown, walAutoCheckpointPages: unknown;
+    try {
+      sqliteVersion = db.prepare('SELECT sqlite_version() AS version').get()!.version;
+      pageBytes = db.prepare('PRAGMA page_size').get()!.page_size;
+      walAutoCheckpointPages = db.prepare('PRAGMA wal_autocheckpoint').get()!.wal_autocheckpoint;
+    }
+    finally { db.close(); }
+    const batches = [];
+    for (const workload of ['execute', 'replay'] as const) for (const processes of [1, 4] as const) {
+      phase = `${workload}-${processes}-process`;
+      batches.push(await runBatch(fixture, workload, processes, workload === 'execute' ? 1_000 : 2_000, workload === 'execute' ? 100 : 200));
+    }
+    phase = 'idle-timers';
+    const idleTimers = [];
+    for (let i = 0; i < 20; i++) {
+      const began = performance.now();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      idleTimers.push(milliseconds(performance.now() - began));
+    }
+    const locked: Awaited<ReturnType<typeof runHeldLock>>[] = [];
+    for (const target of ['replay', 'begin'] as const) for (const holdMs of [250, 6_000]) {
+      phase = `held-lock-${target}-${holdMs}`;
+      locked.push(await runHeldLock(fixture, target, holdMs));
+    }
+    phase = 'provenance';
+    assert.deepEqual(source(repository), initialSource, 'Build or source metadata changed during measurement');
+    fixture.checkDeadline();
+    return { protocol: 'runtime-cost-1', createdAt: new Date().toISOString(), source: initialSource,
+      environment: { node: process.version, sqlite: sqliteVersion, platform: process.platform, arch: process.arch,
+        osRelease: release(), cpuModel: cpus()[0]?.model ?? 'unavailable', logicalCpus: cpus().length, totalMemoryBytes: totalmem() },
+      sqlite: { journalMode: 'WAL', synchronous: 'FULL', busyTimeoutMs: 5_000, pageBytes, walAutoCheckpointPages },
+      timing: { clock: 'performance.now', unit: 'milliseconds', serializedResolution: 0.001,
+        operation: 'Public API plus small intent construction and outcome checks; excludes process startup, setup, warmup and close.',
+        batch: 'Parent start broadcast to all replies, including IPC; fixed aggregate work across process counts.',
+        cpu: 'process.cpuUsage microseconds per measured batch/call, summed across execution processes.',
+        quantiles: 'Nearest rank: ceil(p*n), no interpolation or removal of error samples.' },
+      limits: { workerMs: 25_000, fixtureMs: 60_000 }, elapsedMs: milliseconds(performance.now() - started),
+      batches, locks: { idleTimers, idleTimerMs: statistics(idleTimers), samples: locked,
+        groups: ['replay', 'begin'].flatMap(target => [250, 6_000].map(holdMs => {
+          const samples = locked.filter(sample => sample.target === target && sample.requestedHoldMs === holdMs);
+          return { target, holdMs, latencyMs: statistics(samples.map(sample => sample.elapsedMs)),
+            timerDelayMs: statistics(samples.map(sample => sample.timerDelayMs)), errors: samples.filter(sample => sample.error !== null).length };
+        })) } };
+  } catch (error) { throw new BenchmarkFailure(phase, failure(error).code, error); }
+  finally { await fixture.close(); }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  if (process.argv.length !== 2) {
+    console.error('This benchmark accepts no arguments and creates only its own temporary databases.');
+    process.exitCode = 1;
+  } else {
+    const repository = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+    try {
+      const result = await runtimeBenchmark(repository);
+      mkdirSync(join(repository, 'artifacts'), { recursive: true });
+      writeFileSync(join(repository, 'artifacts/runtime-cost.json'), JSON.stringify(result, null, 2) + '\n');
+      console.table(result.batches.map(batch => ({ workload: batch.name, ...batch.latencyMs, errors: batch.errors })));
+      console.table(result.locks.samples.map(sample => ({ target: sample.target, holdMs: sample.requestedHoldMs,
+        elapsedMs: sample.elapsedMs, timerDelayMs: sample.timerDelayMs, outcome: sample.outcome, error: sample.error?.code ?? '' })));
+      console.log('Raw samples and environment: artifacts/runtime-cost.json');
+    } catch (error) {
+      console.error(error instanceof BenchmarkFailure ? error.message : `Runtime benchmark failed (${failure(error).code})`);
+      console.error('Child reclamation and fixture cleanup were attempted; no successful artifact was written.');
+      process.exitCode = 1;
+    }
+  }
+}

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -77,10 +77,17 @@ for indeterminate actions in v0.2.
 
 ## Storage and clock assumptions
 
-The SQLite adapter uses WAL, FULL synchronization and `BEGIN IMMEDIATE`. The
-linearization point is a successful transaction commit. Transactions contain no
-network work. All accesses, including replay, take the writer lock for simplicity;
-this is not a high-throughput adapter. Busy lock waits are bounded to five seconds.
+The SQLite adapter uses WAL, FULL synchronization and `BEGIN IMMEDIATE` for
+execution grants and changes. Their linearization point is a successful commit.
+Transactions contain no network work. The optional `Store.read` returns one
+validated, committed snapshot without taking a writer lock. `begin` uses it only
+for completed receipts and associated conflicts; that result linearizes at the
+read. All other states are re-read inside the write transaction before deciding.
+Custom adapters without `read` retain the transactional path.
+
+All operations are synchronous. SQLite's busy timeout is configured to 5,000 ms;
+this is not a strict wall-clock deadline for the API call. Reads can still incur
+storage work or fail. See [operation and recovery guidance](operations.md).
 
 Use one database on local disk, with filesystem locking supported by SQLite.
 Network filesystems and replicated database copies are unsupported. The memory
@@ -88,6 +95,11 @@ adapter has neither process coordination nor crash durability. Records with inva
 field types, unknown fields, impossible state combinations or noncanonical results
 throw; they never become a fresh journal. This validates structure, not authenticity:
 someone who can rewrite the database can also forge a structurally valid receipt.
+Size and storage-type guards execute in the same SQLite SELECT that returns each
+record. They bound values passed into JavaScript even when a damaged row is much
+larger. The storage guard permits twice the UTF-8 record budget to accommodate
+UTF-16 databases; the decoder then enforces the exact UTF-8 bound. This is not a
+global memory limit on SQLite, the process or a caller's already allocated input.
 An existing journal with a missing table, missing schema version or multiple
 version rows is rejected. Opening it does not reconstruct lost state as an empty
 journal. A new database path still creates a new journal; protect the database
@@ -111,7 +123,8 @@ extend real elapsed admission time; the journal is not a trusted clock service.
 Once an operation becomes indeterminate it stays so even if the clock moves back.
 Use a stable time source and account for clock error in the integration's contract.
 
-Schema v2 retains v1 identities and fingerprints. On opening a v1 SQLite journal,
+v0.3 keeps schema v2 and needs no migration from v0.2. Schema v2 retains v1
+identities and fingerprints. On opening a v1 SQLite journal,
 the adapter validates and re-encodes records using bounded keyset iteration, then
 updates schema metadata in the same transaction. New time fields are null, never inferred from `leaseUntil` or
 reset to the current time. Completed records replay. Pending legacy idempotent
@@ -125,7 +138,7 @@ Downgrading a migrated database is unsupported. See [upgrade steps](retry-admiss
 
 Input fingerprints are retained instead of raw tool input. Results are stored as
 plaintext JSON. Hashes can reveal low-entropy input through guessing. Protect the
-database and choose result contents accordingly. v0.2 performs no authentication,
+database and choose result contents accordingly. The package performs no authentication,
 encryption, retention cleanup or secure erasure.
 
 Canonical JSON sorts object keys, preserves array order and rejects unsupported

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8,6 +8,19 @@ blocks the event loop while waiting for a lock; applications needing high reques
 concurrency should isolate it in a worker or implement a different Store. A Store
 must provide atomic synchronous read/modify/write and rollback on an exception.
 
+## Read committed receipts without reserving the writer
+
+A completed receipt does not authorize another execution. In v0.3, stores can
+provide an atomic validated read snapshot so this path need not acquire the writer
+lock. The decision linearizes at that read; all pending, absent and indeterminate
+snapshots return to the write transaction and are read again. We do not upgrade a
+read transaction or rerun a user callback automatically after lock contention.
+Stores without the optional method keep their original transactional behavior.
+
+The SQLite query checks the stored type and byte length before returning a value
+to JavaScript. Keeping guards and payload in one SELECT also prevents a writer
+from enlarging the row between a size preflight and a later autocommit read.
+
 ## A journal instead of an agent framework
 
 Retry identity and uncertain side effects are useful beyond chat agents. The core

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,78 @@
+# Operating a local journal
+
+The SQLite adapter coordinates processes on one host using one database on local
+disk. The memory adapter is for tests. Neither provides replicated storage,
+automatic failover or an availability SLA.
+
+## Keep synchronous work off a latency-sensitive event loop
+
+`SqliteStore` uses Node's synchronous SQLite API. A lock wait, storage read,
+serialization or commit occupies its JavaScript thread. Wrapping the call in an
+`async` function or awaiting it does not move that work to another thread.
+
+The busy timeout is configured to 5,000 ms. It controls SQLite's lock retry policy,
+not the total duration of a Journal call. Scheduling, other database work and
+serialization add time. The [runtime experiment](runtime-performance.md) measures
+the actual call and timer delay separately from this configuration.
+
+Where the main event loop must remain responsive, give a worker thread or child
+process ownership of the store and send it commands through a bounded queue.
+Keep a connection in its owner; do not attempt to transfer a live DatabaseSync.
+Account for queue delay when selecting lease durations and renewing ownership.
+The package supplies a synchronous Store contract, not a worker RPC service.
+Timing out an RPC wait does not cancel a command that worker has already accepted.
+
+In v0.3, a completed receipt can be replayed from a committed snapshot while a WAL
+writer is active. This avoids that writer lock; the read remains synchronous and
+can fail. A snapshot of an absent or pending operation never permits execution.
+Only `begin` returning `acquired` supplies that permission. The optional `read`
+method is not an offline forensic opener: constructing a SqliteStore can still
+create a new database or migrate a v1 database.
+
+## Distinguish application ownership from storage contention
+
+| Observation | Meaning and response |
+| --- | --- |
+| `begin` returns `busy` | The committed operation has an unexpired owner. Do not invoke the tool. |
+| SQLite reports `SQLITE_BUSY` while opening or beginning | The database could not obtain the required lock. No new lease was returned. Keep the same logical identity and apply a bounded retry policy; repeated contention needs diagnosis. |
+| `complete` fails in storage | The external action may already have committed. Retain its receipt and investigate; a failed journal write does not undo that action. |
+| `complete` returns `stale` | This lease no longer owns completion. It is not evidence that the external action did not happen. |
+| `begin` returns `indeterminate` | Automatic recovery has insufficient authority. Quiesce old executors and reconcile against the downstream before using `settle`. |
+| A record or schema is rejected | Preserve the database and diagnose the cause. Creating an empty replacement would forget receipts and retry cutoffs. |
+| An AggregateError includes a rollback failure | The adapter closes that connection. Inspect the original failure and cleanup failures before opening another one. |
+
+Report the operation stage and a sanitized error code. Avoid logging raw receipts,
+input, credentials or database contents. The library authenticates neither callers
+nor database files; filesystem access is part of the deployment boundary.
+
+## Back up a consistent and sufficiently recent state
+
+Before changing storage versions, stop old executors and background retries. Use
+[SQLite's backup facilities](https://sqlite.org/backup.html) or a clean shutdown
+of every connection. With WAL active, copying only the main database can omit
+committed data. Preserve the matching application version and configuration.
+
+A consistent snapshot can still be too old to resume execution safely. Actions
+completed after that snapshot may be missing from it. Restoring an absent record
+makes its key appear new, and a downstream provider may already have discarded
+its corresponding idempotency key. The restored journal cannot detect this gap.
+
+Restore into an isolated location with executors stopped. Verify structural
+integrity, version compatibility and the snapshot's operational cutoff; reconcile
+effects since that cutoff using authoritative downstream records. Resume only
+after accounting for that interval. A successful replay of receipts that exist in
+the backup does not prove that no receipts are missing. Do not manufacture new
+keys or reset retry windows to bypass uncertainty.
+
+Protect the configured database path: opening a missing path intentionally creates
+a new journal. A typo, deleted volume or empty mount must be treated as a deployment
+failure when an existing journal was expected. The package cannot infer whether a
+new path is an intended first launch or accidental loss of the old file.
+
+## Limits of the evidence
+
+Process termination, SQLite reopen, synthetic failures and CI checks exercise
+specific boundaries. They do not establish power-loss durability on arbitrary
+hardware, provider cancellation, cross-host fencing or a production service level.
+Operational measurements need the recorded host, workload and software context;
+one local run is not a capacity plan for another deployment.

--- a/docs/runtime-performance.md
+++ b/docs/runtime-performance.md
@@ -56,9 +56,9 @@ holds its reservation. The new-key target preserves the write-contention control
 After release, the caller verifies that the connection can still replay.
 
 The configured SQLite busy timeout is **5,000 ms, not a strict API wall-clock
-upper bound**. A v0.2.0 Windows pilot observed about 5.5 seconds before SQLITE_BUSY.
-Scheduling, timer granularity and SQLite's waiting behavior can affect elapsed
-time; this pilot did not separate those contributions. A timeout says the journal
+upper bound**. Scheduling, timer granularity and SQLite's waiting behavior can
+affect elapsed time; the benchmark does not separate those contributions. Each
+report retains its observed timing and environment. A timeout says the journal
 operation failed to obtain the lock, not that unrelated remote work was canceled.
 
 Journal calls are synchronous, including completed replay. A read fast path can
@@ -70,13 +70,18 @@ define queue limits and failure handling there. Isolation can improve responsive
 it does not create additional SQLite write concurrency or cancel in-flight work.
 
 There is only one long-hold sample per target. For n=1, p50/p95/p99/max are the same
-observation, not estimates of rare-event probability. The default run usually
-takes tens of seconds, largely spent in the two six-second holds. Each child has
-a 25-second deadline; the fixture has a 60-second cleanup deadline. These timers
-also need an event-loop turn and cannot interrupt a synchronous native call in
-the parent. On failure, children are killed and their process/IPC handles are
-awaited before deleting the verified temporary directory. There is no early
-successful exit when a child fails or stops responding.
+observation, not estimates of rare-event probability. The default run includes
+two six-second holds; storage and scheduling can extend it substantially. Each child has
+a 90-second health deadline; the full fixture has a 240-second deadline. The
+worker helper accepts test deadlines up to 120 seconds. These bounds allow slow
+CI machines to perform the original FULL-durability workload; they bound a stalled run
+and are not performance pass thresholds. The CI job retains its 10-minute limit.
+Worker and fixture expiry report `ERR_RUNTIME_WORKER_DEADLINE` and
+`ERR_RUNTIME_FIXTURE_DEADLINE`, respectively, without serializing local paths.
+These timers also need an event-loop turn and cannot interrupt a synchronous
+native call in the parent. On failure, children are killed and their process/IPC
+handles are awaited before deleting the verified temporary directory. There is
+no early successful exit when a child fails or stops responding.
 
 ## Storage, provenance and interpretation
 

--- a/docs/runtime-performance.md
+++ b/docs/runtime-performance.md
@@ -1,0 +1,104 @@
+# Measuring SQLite runtime costs
+
+Run `npm run benchmark:runtime` from a source checkout. The command builds the
+benchmark, creates its own temporary SQLite databases, and writes raw samples to
+`artifacts/runtime-cost.json`. It accepts no database path or other arguments.
+There is no provider, model, network request, or external effect. Core runtime
+dependencies remain empty.
+
+This is a small, closed-loop API microbenchmark. It measures elapsed time with
+`performance.now()`; the existing crash matrix uses logical clocks to test
+correctness and is not a throughput measurement. Neither produces a performance
+score, capacity guarantee, or CI speed threshold.
+
+## Work and timing
+
+| Workload | Processes sharing one database | Measured operations in total | Warmup operations in total |
+| --- | --- | ---: | ---: |
+| Independent keys: `begin` then `complete` | 1, then 4 | 1,000 per configuration | 100 per configuration |
+| One completed receipt: `begin` returns replay | 1, then 4 | 2,000 per configuration | 200 per configuration |
+| Another process holds a write transaction | One caller and one holder | One call per target and hold duration | Completed receipt seeded before timing |
+
+Every worker opens its connection and warms up before sending `ready`. The parent
+broadcasts `start` only after all workers are ready. A measured execution contains
+two journal transactions; a replay contains one public `begin` call. Inputs and
+receipts are fixed small synthetic objects. Payloads are not included in output.
+
+Per-operation timing includes the public API, small intent construction and
+outcome checks. It excludes process startup, imports, database creation, warmup,
+IPC startup, and closing. The aggregate batch interval runs from the parent's
+start broadcast until all result messages arrive, so its rate includes IPC and
+the final result transfer. Workers also report their individual batch durations.
+Do not compare execution and replay as if they performed equal work.
+
+The file retains each request's latency, outcome and error, including timeouts.
+It records n, p50, p95, p99, max, errors, and process CPU time. Quantiles use nearest
+rank, without interpolation or discarding long tails. Durations are rounded to
+0.001 ms when serialized; this formatting is not a claim of microsecond accuracy.
+CPU accounting covers the process, including other threads, and may have coarse
+platform granularity. Small batches can be strongly affected by timers, JIT, GC,
+IPC, OS scheduling and background load.
+
+## Held writer and the event loop
+
+An independent child executes `BEGIN IMMEDIATE`, then sends `locked`. Only after
+that rendezvous does the caller invoke the journal. Each target has a fresh
+fixture: replay an existing completed receipt, or begin a new key. Each is measured
+once with a 250 ms hold and once with a 6,000 ms hold. The holder performs no row
+changes. It reports its actual hold duration and waits for an ACK before closing.
+
+A timer is scheduled immediately before the synchronous call. Its callback delay
+shows how that individual call affects its event loop. Twenty idle timers provide
+a local baseline; the benchmark does not mislabel a tight batch loop as an
+individual API stall. The completed-read result is observed, not fixed: an
+implementation with a committed-read fast path may replay while the writer still
+holds its reservation. The new-key target preserves the write-contention control.
+After release, the caller verifies that the connection can still replay.
+
+The configured SQLite busy timeout is **5,000 ms, not a strict API wall-clock
+upper bound**. A v0.2.0 Windows pilot observed about 5.5 seconds before SQLITE_BUSY.
+Scheduling, timer granularity and SQLite's waiting behavior can affect elapsed
+time; this pilot did not separate those contributions. A timeout says the journal
+operation failed to obtain the lock, not that unrelated remote work was canceled.
+
+Journal calls are synchronous, including completed replay. A read fast path can
+avoid a writer reservation but does not make deserialization or SQLite reads
+asynchronous. `await journal.begin(...)` still runs the call synchronously before
+awaiting its result. Applications that need a responsive HTTP or agent event loop
+should isolate synchronous database work in a dedicated worker or process and
+define queue limits and failure handling there. Isolation can improve responsiveness;
+it does not create additional SQLite write concurrency or cancel in-flight work.
+
+There is only one long-hold sample per target. For n=1, p50/p95/p99/max are the same
+observation, not estimates of rare-event probability. The default run usually
+takes tens of seconds, largely spent in the two six-second holds. Each child has
+a 25-second deadline; the fixture has a 60-second cleanup deadline. These timers
+also need an event-loop turn and cannot interrupt a synchronous native call in
+the parent. On failure, children are killed and their process/IPC handles are
+awaited before deleting the verified temporary directory. There is no early
+successful exit when a child fails or stops responding.
+
+## Storage, provenance and interpretation
+
+An anchor connection stays open while DB, WAL and SHM file lengths are collected
+before and after the measured work. Lengths are collected again after all
+connections close. The output includes net growth. WAL checkpointing can reuse
+space: file length is not cumulative bytes written or write amplification. A
+different checkpoint position can change DB length before close without changing
+the final database size. This benchmark does not measure physical I/O or fsync
+latency, so it cannot attribute a bottleneck to disk bandwidth or device latency.
+
+Output includes source commit, dirty status, dependency-lock hash, hashes of the
+compiled library and harness, Node/SQLite versions, CPU/OS information and SQLite
+settings. It excludes hostname, personal paths, database locations, and result
+payloads. The run rejects a changed build or changed source metadata. A dirty run
+remains labeled dirty and is not evidence for an exact release commit.
+
+Use at least five independent runs for a public before/after comparison. Keep
+aggregate work, payloads, durability settings and table sizes equal; randomize and
+record configuration order outside this fixed-order pilot. State warm/cold cache
+policy and storage type. Publish every run and raw sample, including errors and
+per-worker tails. Do not select the fastest run or infer service capacity under an
+open arrival process. Add profiling and actual I/O evidence before assigning CPU
+or disk blame. For a read-path change, retain the held-writer contrast; for worker
+isolation, report event-loop delay separately from operation completion time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycarllei/tool-journal",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "24.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Durable tool execution with lease fencing, explicit uncertainty, and reproducible crash tests.",
   "license": "MIT",
   "type": "module",
@@ -14,6 +14,7 @@
     "demo": "npm run build && node dist/examples/crash-recovery.js",
     "demo:http": "npm run build && node dist/examples/http-recovery.js",
     "benchmark": "npm run build && node dist/benchmarks/run.js",
+    "benchmark:runtime": "npm run build && node dist/benchmarks/runtime.js",
     "test:mutations": "npm run build && node scripts/mutations.mjs",
     "check:public": "node scripts/check-public.mjs",
     "check:package": "npm run build && node scripts/check-package.mjs",

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -55,7 +55,12 @@ finally { store.close(); }
 `);
   run(['consumer.mjs']);
   writeFileSync(join(directory, 'consumer.mts'), `
-import { Journal, MemoryStore, type Intent, type Begin } from '@raycarllei/tool-journal';
+import { Journal, MemoryStore, type Store, type Intent, type Begin } from '@raycarllei/tool-journal';
+const memory = new MemoryStore();
+const snapshot: ReturnType<MemoryStore['read']> = memory.read('missing');
+const transactionOnly: Store = { transact: memory.transact.bind(memory) };
+new Journal(transactionOnly);
+void snapshot;
 const intent: Intent = { scope: 'types', key: 'one', tool: 'append', input: null, recovery: 'manual' };
 const journal = new Journal(new MemoryStore());
 const result: Begin = journal.begin(intent);

--- a/scripts/mutations.mjs
+++ b/scripts/mutations.mjs
@@ -7,6 +7,7 @@ const file = new URL('../dist/src/journal.js', import.meta.url);
 const original = readFileSync(file, 'utf8');
 const faults = [
   ['ignore changed input', 'entry.fingerprint !== fingerprint', 'false'],
+  ['use a nonterminal snapshot as a final result', "snapshot?.state === 'completed'", 'snapshot !== undefined'],
   ['accept stale execution epochs', 'entry.epoch === lease.epoch && entry.executor === lease.executor', 'true'],
   ['retry without recovery authority', "entry.recovery === 'manual' || entry.retryStartBefore === null || now >= entry.retryStartBefore", 'false'],
   ['admit a retry at or after its cutoff', 'now >= entry.retryStartBefore', 'false'],
@@ -15,7 +16,7 @@ const faults = [
   ['shorten a renewed lease', 'Math.max(entry.leaseUntil, deadline)', 'deadline'],
   ['settle before uncertainty', "entry.state !== 'indeterminate'", 'false'],
 ];
-const tests = ['--test', 'dist/tests/journal.test.js', 'dist/tests/model.test.js', 'dist/tests/integrity.test.js', 'dist/tests/retry-window.test.js'];
+const tests = ['--test', 'dist/tests/journal.test.js', 'dist/tests/model.test.js', 'dist/tests/integrity.test.js', 'dist/tests/retry-window.test.js', 'dist/tests/readonly-replay.test.js'];
 const baseline = spawnSync(process.execPath, tests, { encoding: 'utf8', windowsHide: true, timeout: 30_000 });
 if (baseline.status !== 0) throw new Error('Baseline tests must pass before mutation checks');
 let failed = false;

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -44,6 +44,14 @@ function owns(entry: Entry, lease: Lease): boolean {
   return entry.id === lease.id && entry.epoch === lease.epoch && entry.executor === lease.executor;
 }
 
+function observedOutcome(entry: Entry, fingerprint: string, retryForMs: number | null): Begin | undefined {
+  if (entry.fingerprint !== fingerprint) return { kind: 'conflict' };
+  if (entry.retryForMs !== null && entry.retryForMs !== retryForMs) return { kind: 'conflict' };
+  if (entry.state === 'completed') return { kind: 'replay', result: JSON.parse(entry.result!) as Json };
+  if (entry.state === 'indeterminate') return { kind: 'indeterminate' };
+  return undefined;
+}
+
 export class Journal {
   constructor(private readonly store: Store, private readonly clock: () => number = Date.now) {}
 
@@ -60,15 +68,20 @@ export class Journal {
 
   begin(intent: Intent, leaseMs = 30_000): Begin {
     const { id, fingerprint, recovery, retryForMs } = identity(intent);
+    const snapshot = this.store.read?.(id);
+    if (snapshot?.state === 'completed') {
+      // A committed receipt authorizes no new execution. Its read can linearize
+      // replay without waiting for an unrelated writer. Preserve argument checks.
+      this.deadline(this.now(), leaseMs);
+      return observedOutcome(snapshot, fingerprint, retryForMs)!;
+    }
     return this.store.transact<Begin>(id, entry => {
       // Read time after acquiring the storage lock; lock contention may outlast a lease.
       const now = this.now();
       const leaseUntil = this.deadline(now, leaseMs);
       if (entry) {
-        if (entry.fingerprint !== fingerprint) return { value: { kind: 'conflict' } };
-        if (entry.retryForMs !== null && entry.retryForMs !== retryForMs) return { value: { kind: 'conflict' } };
-        if (entry.state === 'completed') return { value: { kind: 'replay', result: JSON.parse(entry.result!) as Json } };
-        if (entry.state === 'indeterminate') return { value: { kind: 'indeterminate' } };
+        const observed = observedOutcome(entry, fingerprint, retryForMs);
+        if (observed) return { value: observed };
         if (entry.leaseUntil > now) return { value: { kind: 'busy', leaseUntil: entry.leaseUntil } };
         if (entry.recovery === 'manual' || entry.retryStartBefore === null || now >= entry.retryStartBefore) return {
           value: { kind: 'indeterminate' }, next: { ...entry, state: 'indeterminate' },

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -4,6 +4,11 @@ import { decodeEntry, encodeEntry, validateChange, type Store, type Entry, type 
 export class MemoryStore implements Store {
   private readonly entries = new Map<string, string>();
   private inTransaction = false;
+  read(id: string): Entry | undefined {
+    if (this.inTransaction) throw new Error('Nested journal transaction');
+    const raw = this.entries.get(id);
+    return raw === undefined ? undefined : decodeEntry(raw, id);
+  }
   transact<T>(id: string, change: (entry: Entry | undefined) => Change<T>): T {
     if (this.inTransaction) throw new Error('Nested journal transaction');
     this.inTransaction = true;

--- a/src/record.ts
+++ b/src/record.ts
@@ -3,6 +3,9 @@ import { types } from 'node:util';
 
 export type Recovery = 'idempotent' | 'manual';
 
+// A canonical receipt is nested as a JSON string, which can double its byte size.
+export const MAX_RECORD_BYTES = 2 * MAX_JSON_BYTES + 4_096;
+
 export interface Entry {
   version: 2;
   id: string;
@@ -22,9 +25,7 @@ export interface Entry {
 
 /** Invalid persisted state must stop execution, never be treated as an empty journal. */
 export function decodeEntry(raw: string, id: string, version: 1 | 2 = 2): Entry {
-  // A canonical result is nested as a JSON string, which can double its byte size.
-  const limit = 2 * MAX_JSON_BYTES + 4_096;
-  if (raw.length > limit || Buffer.byteLength(raw) > limit) throw new Error('Corrupt journal entry: oversized record');
+  if (raw.length > MAX_RECORD_BYTES || Buffer.byteLength(raw) > MAX_RECORD_BYTES) throw new Error('Corrupt journal entry: oversized record');
   let v: unknown;
   try { v = JSON.parse(raw); }
   catch (cause) { throw new Error('Corrupt journal entry: invalid JSON', { cause }); }
@@ -88,6 +89,8 @@ export function validateChange<T>(change: Change<T>): Change<T> {
   return change;
 }
 export interface Store {
+  /** Optional atomic, validated snapshot. Never authorizes a write; reject nested access. */
+  read?(id: string): Entry | undefined;
   /** Run a synchronous read/modify/write atomically. Throwing rolls back; nested transactions are rejected. */
   transact<T>(id: string, change: (entry: Entry | undefined) => Change<T>): T;
 }

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -1,9 +1,26 @@
-import { DatabaseSync } from 'node:sqlite';
-import { decodeEntry, encodeEntry, validateChange, type Store, type Entry, type Change } from './record.js';
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
+import { decodeEntry, encodeEntry, MAX_RECORD_BYTES, validateChange, type Store, type Entry, type Change } from './record.js';
+
+// octet_length(column) reads size metadata without loading the whole value.
+// SQLite counts in the database encoding; UTF-16 can take twice the UTF-8
+// budget. The decoder still enforces the exact UTF-8 limit after this guard.
+const recordProjection = `typeof(entry) AS storageType,
+  CASE WHEN typeof(entry) = 'text' AND octet_length(entry) <= ${2 * MAX_RECORD_BYTES}
+  THEN entry END AS entry`;
+const migrationProjection = `CASE WHEN typeof(id) = 'text' AND octet_length(id) <= 128
+  THEN id END AS id, ${recordProjection}`;
+
+function decodeRow(row: Record<string, unknown>, id: string, version: 1 | 2 = 2): Entry {
+  if (row.storageType !== 'text') throw new Error('Corrupt journal entry: invalid storage type');
+  if (typeof row.entry !== 'string') throw new Error('Corrupt journal entry: oversized record');
+  return decodeEntry(row.entry, id, version);
+}
 
 /** Local-disk, same-host coordination. Do not put the database on a network filesystem. */
 export class SqliteStore implements Store {
   private readonly db: DatabaseSync;
+  private readonly select: StatementSync;
+  private readonly upsert: StatementSync;
   private inTransaction = false;
   constructor(path: string) {
     this.db = new DatabaseSync(path, { timeout: 5_000 });
@@ -17,18 +34,21 @@ export class SqliteStore implements Store {
         // Recreating a missing records table would forget completed effects.
         throw new Error('Unsupported journal schema: missing table');
       }
-      const versions = this.db.prepare('SELECT version FROM journal_meta LIMIT 2').all();
-      if (versions.length !== 1 || ![1, 2].includes(Number(versions[0]!.version))) throw new Error('Unsupported journal schema');
+      const versions = this.db.prepare(`SELECT CASE WHEN typeof(version) = 'integer' AND version IN (1, 2)
+        THEN version END AS version FROM journal_meta LIMIT 2`).all();
+      if (versions.length !== 1 || (versions[0]!.version !== 1 && versions[0]!.version !== 2)) throw new Error('Unsupported journal schema');
       if (versions[0]?.version === 1) {
         // Keyset iteration bounds memory without updating beneath an active cursor.
         // Decode and re-encode with one JSON parser; SQL JSON functions can resolve
         // duplicate object keys differently. Any bad row rolls back every write.
-        const read = this.db.prepare('SELECT id, entry FROM tool_journal WHERE id > ? ORDER BY id LIMIT 1');
+        const read = this.db.prepare(`SELECT ${migrationProjection} FROM tool_journal
+          WHERE tool_journal.id > ? ORDER BY tool_journal.id LIMIT 1`);
         const write = this.db.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?');
-        let row = this.db.prepare('SELECT id, entry FROM tool_journal ORDER BY id LIMIT 1').get();
+        let row = this.db.prepare(`SELECT ${migrationProjection} FROM tool_journal ORDER BY tool_journal.id LIMIT 1`).get();
         while (row) {
-          const id = String(row.id);
-          const migrated = decodeEntry(String(row.entry), id, 1);
+          if (typeof row.id !== 'string') throw new Error('Corrupt journal entry: invalid identity');
+          const id = row.id;
+          const migrated = decodeRow(row, id, 1);
           write.run(encodeEntry(migrated, id), id);
           row = read.get(id);
         }
@@ -42,21 +62,29 @@ export class SqliteStore implements Store {
           WHEN CASE WHEN json_valid(NEW.entry) THEN json_extract(NEW.entry, '$.version') IS 2 ELSE 0 END = 0
           BEGIN SELECT RAISE(ABORT, 'Unsupported journal entry version'); END;`);
       }
+      this.select = this.db.prepare(`SELECT ${recordProjection} FROM tool_journal WHERE id = ?`);
+      this.upsert = this.db.prepare('INSERT INTO tool_journal VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET entry=excluded.entry');
       this.db.exec('COMMIT');
     } catch (error) {
       this.abort(error, true);
     }
+  }
+  read(id: string): Entry | undefined {
+    if (this.inTransaction) throw new Error('Nested journal transaction');
+    // One SELECT keeps the size/type guards and payload in the same committed
+    // snapshot. A separate preflight query would race another connection.
+    const row = this.select.get(id);
+    return row ? decodeRow(row, id) : undefined;
   }
   transact<T>(id: string, change: (entry: Entry | undefined) => Change<T>): T {
     if (this.inTransaction) throw new Error('Nested journal transaction');
     this.inTransaction = true;
     try {
       this.db.exec('BEGIN IMMEDIATE');
-      const row = this.db.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(id);
-      const { value, next } = validateChange(change(row ? decodeEntry(String(row.entry), id) : undefined));
+      const row = this.select.get(id);
+      const { value, next } = validateChange(change(row ? decodeRow(row, id) : undefined));
       if (next !== undefined) {
-        this.db.prepare('INSERT INTO tool_journal VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET entry=excluded.entry')
-          .run(id, encodeEntry(next, id));
+        this.upsert.run(id, encodeEntry(next, id));
       }
       this.db.exec('COMMIT');
       return value;

--- a/tests/readonly-replay.test.ts
+++ b/tests/readonly-replay.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { test } from 'node:test';
+import { Journal, MemoryStore, SqliteStore, type Intent, type Store } from '../src/index.js';
+
+const intent: Intent = { scope: 'read-replay', key: 'one', tool: 'append', input: { units: 7 }, recovery: 'idempotent', retryForMs: 100 };
+
+function completed(store: Store) {
+  const journal = new Journal(store, () => 0);
+  const begun = journal.begin(intent, 10);
+  assert.equal(begun.kind, 'acquired');
+  if (begun.kind !== 'acquired') throw new Error('Expected a lease');
+  assert.equal(journal.complete(begun.lease, { receipt: 1 }).kind, 'completed');
+  return { journal, id: begun.lease.id };
+}
+
+test('SQLite replays the committed receipt while another connection holds an uncommitted write', () => {
+  const root = realpathSync(tmpdir());
+  const directory = realpathSync(mkdtempSync(join(root, 'journal-read-replay-')));
+  assert.equal(dirname(directory), root);
+  const path = join(directory, 'journal.sqlite');
+  const store = new SqliteStore(path);
+  const writer = new DatabaseSync(path);
+  try {
+    const { journal, id } = completed(store);
+    writer.exec('BEGIN IMMEDIATE');
+    const row = JSON.parse(String(writer.prepare('SELECT entry FROM tool_journal WHERE id = ?').get(id)!.entry));
+    writer.prepare('UPDATE tool_journal SET entry = ? WHERE id = ?')
+      .run(JSON.stringify({ ...row, result: '{"receipt":2}' }), id);
+
+    // The writer stays locked until these assertions return. This proves the
+    // path needs no writer lock without imposing a machine-speed threshold.
+    assert.deepEqual(journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+    assert.deepEqual(journal.begin({ ...intent, input: { units: 8 } }), { kind: 'conflict' });
+    assert.deepEqual(journal.begin({ ...intent, retryForMs: 101 }), { kind: 'conflict' });
+    assert.equal(writer.isTransaction, true);
+    writer.exec('ROLLBACK');
+    assert.deepEqual(journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+  } finally {
+    if (writer.isTransaction) writer.exec('ROLLBACK');
+    writer.close();
+    store.close();
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+for (const adapter of ['memory', 'sqlite'] as const) {
+  test(`${adapter}: completed snapshots preserve validation, isolation and nested-access checks`, () => {
+    const store = adapter === 'memory' ? new MemoryStore() : new SqliteStore(':memory:');
+    try {
+      const { journal, id } = completed(store);
+      for (const duration of [0, -1, 1.5, NaN, Infinity, 86_400_001]) {
+        assert.throws(() => journal.begin(intent, duration), /Lease/);
+      }
+      for (const now of [-1, NaN, Infinity, 0.5]) {
+        assert.throws(() => new Journal(store, () => now).begin(intent), /Clock/);
+      }
+      assert.throws(() => new Journal(store, () => Number.MAX_SAFE_INTEGER).begin(intent, 1), /Lease/);
+      store.transact(id, () => {
+        assert.throws(() => store.read(id), /Nested journal transaction/);
+        assert.throws(() => journal.begin(intent), /Nested journal transaction/);
+        return { value: undefined };
+      });
+      const snapshot = store.read(id)!;
+      snapshot.result = '{"receipt":99}';
+      assert.deepEqual(journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+    } finally { if (store instanceof SqliteStore) store.close(); }
+  });
+}
+
+for (const state of ['absent', 'pending'] as const) {
+  test(`${state} snapshots cannot authorize execution after committed state changes`, () => {
+    const memory = new MemoryStore();
+    const concurrent = new Journal(memory, () => 0);
+    const first = state === 'pending' ? concurrent.begin(intent, 10) : undefined;
+    const wrapper: Store = {
+      read(id) {
+        const snapshot = memory.read(id);
+        if (first?.kind === 'acquired') concurrent.complete(first.lease, { receipt: 1 });
+        else assert.equal(concurrent.begin(intent, 10).kind, 'acquired');
+        return snapshot;
+      },
+      transact: (id, change) => memory.transact(id, change),
+    };
+    assert.deepEqual(new Journal(wrapper, () => 0).begin(intent),
+      state === 'pending' ? { kind: 'replay', result: { receipt: 1 } } : { kind: 'busy', leaseUntil: 10 });
+  });
+}
+
+test('snapshot errors escape without falling back to execution', () => {
+  let transactions = 0;
+  const store: Store = {
+    read() { throw new Error('read unavailable'); },
+    transact() { transactions++; throw new Error('must not transact'); },
+  };
+  assert.throws(() => new Journal(store).begin(intent), /read unavailable/);
+  assert.equal(transactions, 0);
+});
+
+test('an adapter without read retains the transactional replay path', () => {
+  const memory = new MemoryStore();
+  let transactions = 0;
+  const legacy: Store = { transact(id, change) { transactions++; return memory.transact(id, change); } };
+  const { journal } = completed(legacy);
+  assert.equal(transactions, 2);
+  assert.deepEqual(journal.begin(intent), { kind: 'replay', result: { receipt: 1 } });
+  assert.equal(transactions, 3);
+});

--- a/tests/runtime-benchmark.test.ts
+++ b/tests/runtime-benchmark.test.ts
@@ -61,7 +61,7 @@ test('malformed worker failures reject through cleanup without an uncaught IPC e
   try {
     for (const message of malformed) {
       const worker = fixture.worker(['-e',
-        `process.on('message', () => {}); process.send(${JSON.stringify(message)});`]);
+        "process.on('message', () => {}); process.send(JSON.parse(process.argv[1]));", JSON.stringify(message)]);
       await assert.rejects(worker.receive('ready'), /Unexpected runtime worker failure message/);
       await worker.closed;
     }

--- a/tests/runtime-benchmark.test.ts
+++ b/tests/runtime-benchmark.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
-import { RuntimeChild, RuntimeFixture } from '../benchmarks/runtime-process.js';
+import { RuntimeChild, RuntimeFixture, failure } from '../benchmarks/runtime-process.js';
 import { runBatch, runHeldLock } from '../benchmarks/runtime.js';
 
 test('runtime batch reports measured requests separately from warmup across real workers', async () => {
@@ -75,7 +75,12 @@ test('malformed worker failures reject through cleanup without an uncaught IPC e
 
 test('a silent worker is killed at its deadline before the waiter rejects', async () => {
   const worker = new RuntimeChild(['-e', 'process.on("message", () => {});'], 200);
-  await assert.rejects(worker.receive('ready'), /deadline/);
+  await assert.rejects(worker.receive('ready'), error => {
+    assert.ok(error instanceof Error);
+    assert.match(error.message, /deadline/);
+    assert.deepEqual(failure(error), { code: 'ERR_RUNTIME_WORKER_DEADLINE', sqliteCode: null });
+    return true;
+  });
   await worker.closed;
   await worker.stop();
 });

--- a/tests/runtime-benchmark.test.ts
+++ b/tests/runtime-benchmark.test.ts
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { RuntimeChild, RuntimeFixture } from '../benchmarks/runtime-process.js';
+import { runBatch, runHeldLock } from '../benchmarks/runtime.js';
+
+test('runtime batch reports measured requests separately from warmup across real workers', async () => {
+  const fixture = new RuntimeFixture();
+  try {
+    const batch = await runBatch(fixture, 'execute', 4, 8, 4);
+    assert.equal(batch.latencyMs.n, 8);
+    assert.equal(batch.errors, 0);
+    assert.equal(batch.workers.length, 4);
+    for (const worker of batch.workers) {
+      assert.deepEqual(worker.samples.map(sample => sample.sequence), [0, 1]);
+      assert.ok(worker.samples.every(sample => sample.outcome === 'completed'));
+    }
+    const db = new DatabaseSync(join(fixture.directory, 'execute-4-process.sqlite'));
+    try { assert.equal(db.prepare('SELECT count(*) AS n FROM tool_journal').get()!.n, 12); }
+    finally { db.close(); }
+  } finally { await fixture.close(); }
+  assert.equal(existsSync(fixture.directory), false);
+});
+
+test('held-writer protocol observes both completed reads and new writes without a speed assertion', async () => {
+  const fixture = new RuntimeFixture();
+  try {
+    const replay = await runHeldLock(fixture, 'replay', 50);
+    const begin = await runHeldLock(fixture, 'begin', 50);
+    assert.equal(replay.outcome, 'replay');
+    assert.equal(begin.outcome, 'acquired');
+    assert.equal(replay.error, null);
+    assert.equal(begin.error, null);
+    assert.ok(Number.isFinite(replay.timerDelayMs));
+    assert.ok(Number.isFinite(begin.timerDelayMs));
+    assert.equal(replay.storageBytes.measuredNetGrowth.wal, 0);
+  } finally { await fixture.close(); }
+});
+
+test('an early worker exit rejects its pending reply and closes IPC', async () => {
+  const worker = new RuntimeChild(['-e', 'process.exit(7)']);
+  await assert.rejects(worker.receive('ready'), /exited/);
+  await worker.closed;
+  await worker.stop();
+});
+
+test('malformed worker failures reject through cleanup without an uncaught IPC exception', async () => {
+  const fixture = new RuntimeFixture();
+  const malformed = [
+    { kind: 'failed' },
+    { kind: 'failed', error: null },
+    { kind: 'failed', error: 'broken' },
+    { kind: 'failed', error: {} },
+    { kind: 'failed', error: { code: 42, sqliteCode: null } },
+    { kind: 'failed', error: { code: 'not-a-public-code', sqliteCode: null } },
+    { kind: 'failed', error: { code: 'ERR_SQLITE_ERROR' } },
+    { kind: 'failed', error: { code: 'ERR_SQLITE_ERROR', sqliteCode: '5' } },
+  ];
+  try {
+    for (const message of malformed) {
+      const worker = fixture.worker(['-e',
+        `process.on('message', () => {}); process.send(${JSON.stringify(message)});`]);
+      await assert.rejects(worker.receive('ready'), /Unexpected runtime worker failure message/);
+      await worker.closed;
+    }
+    const valid = fixture.worker(['-e',
+      `process.on('message', () => {}); process.send({kind:'failed',error:{code:'ERR_SQLITE_ERROR',sqliteCode:5}});`]);
+    await assert.rejects(valid.receive('ready'), /Runtime worker reported ERR_SQLITE_ERROR/);
+    await valid.closed;
+  } finally { await fixture.close(); }
+  assert.equal(existsSync(fixture.directory), false);
+});
+
+test('a silent worker is killed at its deadline before the waiter rejects', async () => {
+  const worker = new RuntimeChild(['-e', 'process.on("message", () => {});'], 200);
+  await assert.rejects(worker.receive('ready'), /deadline/);
+  await worker.closed;
+  await worker.stop();
+});
+
+test('fixture cleanup reclaims an active child before removing its own directory', async () => {
+  const fixture = new RuntimeFixture();
+  const worker = fixture.worker(['-e', 'process.on("message", () => {}); process.send({kind:"ready"});']);
+  try { await worker.receive('ready'); }
+  finally { await fixture.close(); }
+  await worker.closed;
+  assert.equal(existsSync(fixture.directory), false);
+});

--- a/tests/sqlite-materialization.test.ts
+++ b/tests/sqlite-materialization.test.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { DatabaseSync, StatementSync } from 'node:sqlite';
+import { test, type TestContext } from 'node:test';
+import { Journal, SqliteStore, type Intent } from '../src/index.js';
+
+// Wire-format limits, deliberately independent of the implementation's SQL.
+const recordBytes = 2 * 1_048_576 + 4_096;
+const storageBytes = 2 * recordBytes;
+const id = 'a'.repeat(64);
+
+function withFile(run: (path: string, raw: DatabaseSync) => void): void {
+  const root = realpathSync(tmpdir());
+  const directory = realpathSync(mkdtempSync(join(root, 'journal-materialization-')));
+  assert.equal(dirname(directory), root);
+  const path = join(directory, 'journal.sqlite');
+  const raw = new DatabaseSync(path);
+  try { run(path, raw); }
+  finally {
+    try { raw.close(); }
+    finally { rmSync(directory, { recursive: true, force: true }); }
+  }
+}
+
+function createSchema(raw: DatabaseSync, version: 1 | 2, encoding?: string): void {
+  if (encoding) raw.exec(`PRAGMA encoding = '${encoding}'`);
+  raw.exec(`CREATE TABLE journal_meta (version INTEGER NOT NULL) STRICT;
+    INSERT INTO journal_meta VALUES (${version});
+    CREATE TABLE tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT;`);
+}
+
+function entry(version: 1 | 2, result: string | null = null, identity = id): string {
+  return JSON.stringify({
+    version, id: identity, fingerprint: 'b'.repeat(64), recovery: 'manual',
+    state: result === null ? 'pending' : 'completed', epoch: 1,
+    executor: 'materialization-test', leaseUntil: 10, result,
+    ...(version === 2 ? { firstAcquiredAt: 0, retryForMs: null, retryStartBefore: null } : {}),
+  });
+}
+
+interface ObservedRead { field: string; bytes: number }
+
+/** Observe values the native wrapper actually hands to JS, not just SQL text. */
+function observeReads(t: TestContext, action: () => void): ObservedRead[] {
+  const observed: ObservedRead[] = [];
+  const inspect = (row: Record<string, unknown> | undefined) => {
+    if (!row) return;
+    for (const [field, value] of Object.entries(row)) {
+      if (typeof value === 'string') observed.push({ field, bytes: Buffer.byteLength(value) });
+      else if (ArrayBuffer.isView(value)) observed.push({ field, bytes: value.byteLength });
+    }
+  };
+  const originalGet = StatementSync.prototype.get;
+  const originalAll = StatementSync.prototype.all;
+  const get = t.mock.method(StatementSync.prototype, 'get', function (this: StatementSync, ...parameters: unknown[]) {
+    const row = Reflect.apply(originalGet, this, parameters) as ReturnType<StatementSync['get']>;
+    inspect(row);
+    return row;
+  });
+  const all = t.mock.method(StatementSync.prototype, 'all', function (this: StatementSync, ...parameters: unknown[]) {
+    const rows = Reflect.apply(originalAll, this, parameters) as ReturnType<StatementSync['all']>;
+    for (const row of rows) inspect(row);
+    return rows;
+  });
+  try { action(); }
+  finally { get.mock.restore(); all.mock.restore(); }
+  return observed;
+}
+
+function assertBounded(reads: ObservedRead[], limit = storageBytes): void {
+  assert.ok(reads.every(read => read.bytes <= limit),
+    `SQLite returned an oversized value before validation: ${JSON.stringify(reads.filter(read => read.bytes > limit))}`);
+}
+
+test('an oversized current record never reaches JS or its transaction callback', t => {
+  withFile((path, raw) => {
+    const store = new SqliteStore(path);
+    try {
+      const intent: Intent = { scope: 'bounded-read', key: 'one', tool: 'append', input: {}, recovery: 'manual' };
+      const journal = new Journal(store, () => 0);
+      const begun = journal.begin(intent, 10);
+      assert.equal(begun.kind, 'acquired');
+      if (begun.kind !== 'acquired') throw new Error('Expected a lease');
+      const original = raw.prepare('SELECT entry FROM tool_journal WHERE id=?').get(begun.lease.id)!.entry as string;
+      const oversized = JSON.stringify({ ...JSON.parse(original), state: 'completed', result: JSON.stringify('x'.repeat(storageBytes)) });
+      raw.prepare('UPDATE tool_journal SET entry=? WHERE id=?').run(oversized, begun.lease.id);
+      let entered = false;
+      const reads = observeReads(t, () => {
+        assert.throws(() => store.transact(begun.lease.id, () => {
+          entered = true;
+          return { value: 'must not run' };
+        }), /Corrupt journal entry/);
+      });
+      assert.equal(entered, false);
+      assertBounded(reads);
+      assert.equal(raw.prepare('SELECT entry=? AS unchanged FROM tool_journal WHERE id=?').get(oversized, begun.lease.id)!.unchanged, 1);
+      // The failed read releases its writer lock and preserves the old lease.
+      raw.prepare('UPDATE tool_journal SET entry=? WHERE id=?').run(original, begun.lease.id);
+      assert.deepEqual(journal.begin(intent, 10), { kind: 'busy', leaseUntil: 10 });
+    } finally { store.close(); }
+  });
+});
+
+test('an oversized autocommit snapshot never returns its payload to JS', t => {
+  withFile((path, raw) => {
+    const store = new SqliteStore(path);
+    try {
+      const original = entry(2);
+      const oversized = entry(2, JSON.stringify('x'.repeat(storageBytes)));
+      raw.prepare('INSERT INTO tool_journal VALUES (?, ?)').run(id, oversized);
+      const reads = observeReads(t, () => {
+        assert.throws(() => store.read(id), /Corrupt journal entry/);
+      });
+      assertBounded(reads);
+      assert.equal(raw.prepare('SELECT entry=? AS unchanged FROM tool_journal WHERE id=?').get(oversized, id)!.unchanged, 1);
+      raw.prepare('UPDATE tool_journal SET entry=? WHERE id=?').run(original, id);
+      assert.equal(store.read(id)!.state, 'pending');
+    } finally { store.close(); }
+  });
+});
+
+test('migration rejects oversized TEXT before materialization and retains the original rows', t => {
+  withFile((path, raw) => {
+    createSchema(raw, 1);
+    const good = entry(1);
+    const badId = 'c'.repeat(64);
+    const oversized = entry(1, JSON.stringify('x'.repeat(storageBytes)), badId);
+    raw.prepare('INSERT INTO tool_journal VALUES (?, ?), (?, ?)').run(id, good, badId, oversized);
+    let opened: SqliteStore | undefined;
+    const reads = observeReads(t, () => {
+      try { assert.throws(() => { opened = new SqliteStore(path); }, /Corrupt journal entry/); }
+      finally { opened?.close(); }
+    });
+    assertBounded(reads);
+    assert.equal(raw.prepare('SELECT version FROM journal_meta').get()!.version, 1);
+    assert.equal(raw.prepare('SELECT entry=? AS unchanged FROM tool_journal WHERE id=?').get(good, id)!.unchanged, 1);
+    assert.equal(raw.prepare('SELECT entry=? AS unchanged FROM tool_journal WHERE id=?').get(oversized, badId)!.unchanged, 1);
+    raw.exec('BEGIN IMMEDIATE; ROLLBACK;');
+    raw.prepare('UPDATE tool_journal SET entry=? WHERE id=?').run(entry(1, null, badId), badId);
+    const repaired = new SqliteStore(path);
+    try { assert.equal(repaired.transact(id, current => ({ value: current!.version })), 2); }
+    finally { repaired.close(); }
+  });
+});
+
+test('migration refuses an oversized identity without returning that identity to JS', t => {
+  withFile((path, raw) => {
+    createSchema(raw, 1);
+    const largeId = 'f'.repeat(256 * 1024);
+    const encoded = entry(1, null, largeId);
+    raw.prepare('INSERT INTO tool_journal VALUES (?, ?)').run(largeId, encoded);
+    let opened: SqliteStore | undefined;
+    const reads = observeReads(t, () => {
+      try { assert.throws(() => { opened = new SqliteStore(path); }, /Corrupt journal entry/); }
+      finally { opened?.close(); }
+    });
+    assertBounded(reads.filter(read => read.field === 'id'), 128);
+    assert.equal(raw.prepare('SELECT version FROM journal_meta').get()!.version, 1);
+    assert.equal(raw.prepare('SELECT id=? AND entry=? AS unchanged FROM tool_journal').get(largeId, encoded)!.unchanged, 1);
+    raw.exec('BEGIN IMMEDIATE; ROLLBACK;');
+  });
+});
+
+for (const [name, expression] of [
+  ['text version', "'2'"],
+  ['real version', '2.0'],
+  ['blob version', "x'02'"],
+  ['oversized version', `printf('%.*c', ${storageBytes + 1}, '2')`],
+] as const) {
+  test(`opening a journal rejects ${name} without returning an oversized metadata value`, t => {
+    withFile((path, raw) => {
+      // ANY preserves the wrong storage type instead of INTEGER affinity fixing it.
+      raw.exec(`CREATE TABLE journal_meta (version ANY NOT NULL) STRICT;
+        INSERT INTO journal_meta VALUES (${expression});
+        CREATE TABLE tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT;`);
+      raw.prepare('INSERT INTO tool_journal VALUES (?, ?)').run(id, entry(2));
+      const before = raw.prepare('SELECT typeof(version) AS type, octet_length(version) AS bytes FROM journal_meta').get();
+      let opened: SqliteStore | undefined;
+      const reads = observeReads(t, () => {
+        try { assert.throws(() => { opened = new SqliteStore(path); }, /Unsupported journal schema/); }
+        finally { opened?.close(); }
+      });
+      assertBounded(reads);
+      assert.deepEqual(raw.prepare('SELECT typeof(version) AS type, octet_length(version) AS bytes FROM journal_meta').get(), before);
+      assert.equal(raw.prepare('SELECT count(*) AS count FROM tool_journal').get()!.count, 1);
+      assert.equal(raw.prepare("SELECT count(*) AS count FROM sqlite_master WHERE type='trigger'").get()!.count, 0);
+      raw.exec('BEGIN IMMEDIATE; ROLLBACK;');
+    });
+  });
+}
+
+for (const version of [1, 2] as const) {
+  for (const encoding of ['UTF-16le', 'UTF-16be']) {
+    test(`version ${version} accepts a valid large ${encoding} receipt containing non-ASCII text`, t => {
+      withFile((path, raw) => {
+        createSchema(raw, version, encoding);
+        // Escaped quotes make the outer record larger than the canonical result.
+        // UTF-16 storage exceeds the UTF-8 limit without violating that limit.
+        const result = '\u0080"'.repeat(240_000) + '汉';
+        const encoded = entry(version, JSON.stringify(result));
+        assert.ok(Buffer.byteLength(JSON.stringify(result)) < 1_048_576);
+        assert.ok(Buffer.byteLength(encoded) < recordBytes);
+        raw.prepare('INSERT INTO tool_journal VALUES (?, ?)').run(id, encoded);
+        const stored = raw.prepare('SELECT octet_length(entry) AS bytes FROM tool_journal').get()!.bytes as number;
+        assert.ok(stored > recordBytes && stored <= storageBytes);
+        let store: SqliteStore | undefined;
+        try {
+          const reads = observeReads(t, () => {
+            store = new SqliteStore(path);
+            const replay = store.transact(id, current => ({ value: current!.result }));
+            assert.equal(JSON.parse(replay!), result);
+          });
+          assertBounded(reads);
+          assert.equal(raw.prepare('SELECT version FROM journal_meta').get()!.version, 2);
+        } finally { store?.close(); }
+      });
+    });
+  }
+}


### PR DESCRIPTION
Completed receipts previously acquired SQLite's writer reservation, so an unrelated writer could block replay and its event loop. Oversized persisted values were also materialized in JavaScript before the decoder rejected them.

Use a single bounded SELECT for validated completed snapshots; all execution claims still reread inside the write transaction. Guard record and migration projections before values cross into JavaScript, retain UTF-16 compatibility and exact decoded limits, reject noninteger schema metadata, and reuse connection-local statements. Schema v2 and transaction-only custom stores remain compatible.

Add a reproducible runtime-cost experiment with raw samples, held-writer controls, event-loop probes and source/build provenance. Document synchronous-operation isolation, busy errors, backup recovery and measurement limits. This prepares version 0.3.0; it introduces no cross-service exactly-once or availability guarantee.

Validation: 141 tests, nine targeted mutations, offline packaged-consumer/type checks, seven LangGraph integration tests and both recovery demos passed locally. The harness has real-child regressions for early exits, deadlines, malformed IPC failures and cleanup. A development runtime experiment retained 6,000 batch samples and four held-writer observations; its dirty build is explicitly labeled and is not release evidence. CI runs the final crash and runtime experiments on three operating systems and two Node versions.
