### PR TITLE
Refuse erased journal schemas and verify CI package candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,23 @@ jobs:
           path: artifacts/runtime-cost.json
           if-no-files-found: error
           retention-days: 30
+  package:
+    needs: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.15.0'
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run release:candidate
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: package-candidate-${{ github.sha }}
+          path: artifacts/package-candidate-*/*
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.1
+
+- Refuse automatic initialization when both journal tables are absent but SQLite
+  retains schema history or other schema objects. Missing tables in an existing
+  database must not turn completed effects into fresh execution grants.
+- Reject stale compiled modules in package checks. Candidate packages contain
+  exactly the source-derived library outputs and public documentation.
+- Generate the tested package, source/build record and checksums after the full
+  CI matrix. Document local reproduction and release promotion without granting
+  the workflow publication credentials.
+
 ## 0.3.0
 
 - Replay completed receipts through an optional validated Store snapshot. SQLite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ with an explicit rendezvous is more useful than a timing-dependent sleep.
 type-checks its public API. The model tests print fast-check's seed and shrink path
 on failure; include both when reporting a sequence-dependent bug.
 
+The [release guide](docs/releases.md) describes the candidate package produced by
+CI and how to reproduce its offline consumer check and source/checksum record.
+
 Keep changes bounded. New storage adapters need the same conflict, fencing,
 reopen and crash tests as SQLite. The present Store contract is synchronous;
 an asynchronous database needs an API design change, not a cast hiding a Promise.

--- a/README.md
+++ b/README.md
@@ -61,17 +61,21 @@ library archive through the public API. No model key or external service is need
 
 ## Use the journal
 
-Download the `.tgz` from the [v0.3.0 release](https://github.com/RaycarlLei/tool-journal/releases/tag/v0.3.0)
+Download the `.tgz` from the [v0.3.1 release](https://github.com/RaycarlLei/tool-journal/releases/tag/v0.3.1)
 and install it in your application:
 
 ```sh
-npm install ./raycarllei-tool-journal-0.3.0.tgz
+npm install ./raycarllei-tool-journal-0.3.1.tgz
 ```
 
 The archive contains compiled JavaScript and TypeScript declarations. To build it
 yourself, run `npm pack` in this checkout. The package has no install-time hooks or
 runtime dependencies; the crash experiments and framework example stay in the
 source repository.
+
+CI also saves the exact archive that passed the offline consumer check, with its
+source identity and checksums. See the [release guide](docs/releases.md) to build
+and inspect a candidate locally.
 
 ```ts
 import { Journal, SqliteStore } from '@raycarllei/tool-journal';

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -101,9 +101,15 @@ larger. The storage guard permits twice the UTF-8 record budget to accommodate
 UTF-16 databases; the decoder then enforces the exact UTF-8 bound. This is not a
 global memory limit on SQLite, the process or a caller's already allocated input.
 An existing journal with a missing table, missing schema version or multiple
-version rows is rejected. Opening it does not reconstruct lost state as an empty
-journal. A new database path still creates a new journal; protect the database
-file and restore a consistent backup if it is lost.
+version rows is rejected. When both journal tables are absent, initialization
+requires no schema objects and SQLite's `schema_version` to be zero. These checks
+run inside the opening transaction: a database retaining schema history is not
+silently rebuilt as an empty journal, and an unrelated schema is not populated
+with journal tables. The counter is not authentication and can be reset outside
+the library. A missing path or a replacement empty file still creates a new
+journal; neither lost storage nor an overly old backup can be identified from
+these checks. Protect the database and reconcile a restored backup's missing
+interval before resuming execution.
 
 Both adapters reject nested transactions and asynchronous callbacks. The callback
 must return a `Change` synchronously. Rejection prevents a returned change from being

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -69,6 +69,16 @@ a new journal. A typo, deleted volume or empty mount must be treated as a deploy
 failure when an existing journal was expected. The package cannot infer whether a
 new path is an intended first launch or accidental loss of the old file.
 
+If both journal tables are absent, initialization requires an empty schema and
+SQLite's `schema_version` counter to be zero. A database with unrelated schema
+objects or retained schema history is rejected without rebuilding journal tables
+or granting a new lease. Existing schema contents and user rows are preserved;
+opening still configures SQLite and is not a forensic, read-only operation.
+Do not delete schema objects or reset the counter to get past this rejection.
+The counter is not authentication: an external reset, replacement with an empty
+file, or a consistent but overly old backup can hide the history that is missing.
+Keep executors stopped and follow the reconciliation procedure above.
+
 ## Limits of the evidence
 
 Process termination, SQLite reopen, synthetic failures and CI checks exercise

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,75 @@
+# Build and inspect a package candidate
+
+The public workflow creates a package candidate after the six OS/Node checks
+pass. It has read-only repository permissions and does not create a release,
+change a tag, or publish to a registry. Pull-request candidates refer to the
+tested merge commit; only a successful main run is a release source.
+
+## Reproduce locally
+
+Start from a clean checkout of the commit you want to inspect, using the Node
+version recorded in the workflow and the checked-in lockfile:
+
+```sh
+npm ci --ignore-scripts
+npm run check
+npm run release:candidate
+```
+
+The command prints a new directory under `artifacts/package-candidate-*` with
+three files:
+
+- The compiled `.tgz` archive that passed the offline consumer check.
+- `build-provenance.json`: source commit and tree, lockfile SHA-256, Node/npm and
+  platform versions, package members, and the archive SHA-256.
+- `SHA256SUMS`: hashes of the archive and provenance file, written last.
+
+The consumer installs the archive without network access or lifecycle hooks,
+completes an operation through the public API, reopens SQLite to replay it, and
+compiles a TypeScript consumer. Candidate generation rejects uncommitted source
+and checks that the commit and tree have not changed during verification. It
+copies that tested archive; it does not repack after testing.
+
+Use a new candidate directory for each attempt. A directory without SHA256SUMS
+is incomplete. Generated directories are ignored by Git and are never source
+inputs. Local generation runs the package check, not the other operating systems
+or the LangGraph suite; see the corresponding CI run for those results.
+
+## Download and check a CI candidate
+
+Open a successful **Journal checks** run and download the
+`package-candidate-<commit>` artifact. GitHub requires a signed-in account to
+download workflow artifacts, and they expire after 30 days. Published releases
+remain the distribution channel for users.
+
+Extract the artifact into a new directory and locate the three files. On systems
+with `sha256sum`, run this inside that directory:
+
+```sh
+sha256sum --check SHA256SUMS
+```
+
+On PowerShell, `Get-FileHash *.tgz, build-provenance.json -Algorithm SHA256`
+prints the corresponding values for comparison with SHA256SUMS. Compare the
+provenance commit with the workflow's tested commit, then inspect that commit's
+source and checks. A green pull-request run is not proof that its merge result
+is the released source; use the final main run.
+
+## Promote deliberately
+
+Before a release, update the package version and lockfile, changelog, supported
+version policy and installation instructions in the normal reviewed change.
+After merging, require successful checks for that exact main commit. Download
+its candidate and verify the hashes and source identity before publishing the
+same archive. Keep any experiment reports tied to that same source; their
+metadata and workload results need separate inspection.
+
+After publication, download the public assets again and compare their hashes.
+Do not replace an existing version's tag or archive to correct a bad release;
+publish a new version with the correction explained.
+
+These files record build inputs and detect mismatched bytes. They are not a
+cryptographic attestation, an independent security review, or a claim that every
+host produces a byte-identical archive. Trust still includes the reviewed source,
+the workflow, its dependencies and the distribution account. Never include
+credentials, local database files or private logs in a candidate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycarllei/tool-journal",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "24.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycarllei/tool-journal",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Durable tool execution with lease fencing, explicit uncertainty, and reproducible crash tests.",
   "license": "MIT",
   "type": "module",
@@ -18,6 +18,7 @@
     "test:mutations": "npm run build && node scripts/mutations.mjs",
     "check:public": "node scripts/check-public.mjs",
     "check:package": "npm run build && node scripts/check-package.mjs",
+    "release:candidate": "npm run build && node scripts/check-package.mjs --candidate",
     "check": "npm test && npm run test:mutations && npm run check:public && npm run check:package",
     "prepack": "npm run build"
   },

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -9,8 +10,23 @@ const root = fileURLToPath(new URL('../', import.meta.url));
 const npm = process.env.npm_execpath;
 assert.ok(npm, 'Run this check through npm run check:package');
 const tempRoot = resolve(tmpdir());
-const directory = mkdtempSync(join(tempRoot, 'tool-journal-package-'));
 const manifest = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+assert.ok(process.argv.length === 2 || (process.argv.length === 3 && process.argv[2] === '--candidate'),
+  'Only --candidate is accepted');
+const candidate = process.argv[2] === '--candidate';
+function git(...args) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8', windowsHide: true, timeout: 10_000 }).trim();
+}
+function source() {
+  assert.equal(git('status', '--porcelain'), '', 'Commit the source before creating a package candidate');
+  const commit = git('rev-parse', 'HEAD');
+  const tree = git('rev-parse', 'HEAD^{tree}');
+  assert.match(commit, /^[a-f0-9]{40}$/);
+  assert.match(tree, /^[a-f0-9]{40}$/);
+  return { commit, tree };
+}
+function sha256(path) { return createHash('sha256').update(readFileSync(path)).digest('hex'); }
+const candidateSource = candidate ? source() : undefined;
 for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies', 'bundledDependencies', 'bundleDependencies']) {
   const value = manifest[field];
   assert.ok(value === undefined || (value !== null && typeof value === 'object' && Object.keys(value).length === 0),
@@ -23,6 +39,7 @@ function run(args, cwd = directory) {
   });
 }
 
+const directory = mkdtempSync(join(tempRoot, 'tool-journal-package-'));
 try {
   const [archive] = JSON.parse(run([npm, 'pack', '--ignore-scripts', '--json', '--pack-destination', directory], root));
   const names = archive.files.map(file => file.path);
@@ -32,6 +49,16 @@ try {
     assert.ok(/^(?:dist\/src\/[a-z-]+\.(?:js|d\.ts)|docs\/[a-z-]+\.md|package\.json|README\.md|LICENSE)$/.test(name),
       `Unexpected package member: ${name}`);
   }
+  const sources = git('ls-files', '--cached', '--others', '--exclude-standard').split('\n');
+  const expected = new Set(['package.json', 'README.md', 'LICENSE']);
+  for (const name of sources) {
+    if (/^docs\/[a-z-]+\.md$/.test(name)) expected.add(name);
+    if (/^src\/[a-z-]+\.ts$/.test(name)) {
+      expected.add(`dist/${name.slice(0, -3)}.js`);
+      expected.add(`dist/${name.slice(0, -3)}.d.ts`);
+    }
+  }
+  assert.deepEqual([...names].sort(), [...expected].sort(), 'Package contains stale or missing source outputs');
   // Install only the produced archive, without network access or lifecycle hooks.
   // Dependency policy is checked explicitly above; a warm cache is not evidence.
   writeFileSync(join(directory, 'package.json'), JSON.stringify({ private: true, type: 'module' }));
@@ -75,6 +102,35 @@ const manualWindow: Intent = { scope: 'types', key: 'three', tool: 'append', inp
 `);
   run([join(root, 'node_modules/typescript/bin/tsc'), '--noEmit', '--strict', '--module', 'NodeNext',
     '--moduleResolution', 'NodeNext', '--target', 'ES2023', 'consumer.mts']);
+  if (candidate) {
+    assert.deepEqual(source(), candidateSource, 'Source changed during package verification');
+    assert.equal(basename(archive.filename), archive.filename);
+    const archivePath = join(directory, archive.filename);
+    const archiveSha256 = sha256(archivePath);
+    const provenance = {
+      schemaVersion: 1,
+      package: { name: manifest.name, version: manifest.version, file: archive.filename, sha256: archiveSha256 },
+      source: { ...candidateSource, lockSha256: sha256(join(root, 'package-lock.json')) },
+      build: { node: process.version, npm: run([npm, '--version']).trim(), platform: process.platform, arch: process.arch },
+      verification: ['exact package members from source', 'offline install without hooks', 'SQLite reopen', 'public TypeScript consumer'],
+      members: [...names].sort(),
+    };
+    // A new directory prevents stale or partly overwritten bundles from being
+    // mistaken for this run. Copy the archive that the consumer actually tested.
+    const artifacts = join(root, 'artifacts');
+    mkdirSync(artifacts, { recursive: true });
+    assert.equal(dirname(realpathSync(artifacts)), realpathSync(root));
+    assert.equal(basename(realpathSync(artifacts)), 'artifacts');
+    const destination = mkdtempSync(join(artifacts, 'package-candidate-'));
+    copyFileSync(archivePath, join(destination, archive.filename));
+    assert.equal(sha256(join(destination, archive.filename)), archiveSha256);
+    const provenancePath = join(destination, 'build-provenance.json');
+    writeFileSync(provenancePath, JSON.stringify(provenance, null, 2) + '\n', { flag: 'wx' });
+    // Write the manifest last. A directory without it is an incomplete candidate.
+    writeFileSync(join(destination, 'SHA256SUMS'),
+      `${archiveSha256}  ${archive.filename}\n${sha256(provenancePath)}  build-provenance.json\n`, { flag: 'wx' });
+    console.log(`Verified candidate: artifacts/${basename(destination)}`);
+  }
   console.log(`Package ${manifest.name}@${manifest.version}: allowlist, offline install, SQLite reopen and public types passed.`);
 } finally {
   assert.equal(dirname(resolve(directory)), tempRoot);

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -29,6 +29,13 @@ export class SqliteStore implements Store {
       this.db.exec('BEGIN IMMEDIATE');
       const tables = this.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('journal_meta', 'tool_journal')").all();
       if (tables.length === 0) {
+        // Missing both tables is not proof of a first launch. Refuse to forget
+        // a used schema or add journal state to an unrelated application's DB.
+        const schemaObject = this.db.prepare('SELECT 1 AS present FROM sqlite_master LIMIT 1').get();
+        const schemaVersion = this.db.prepare('PRAGMA schema_version').get()!.schema_version;
+        if (schemaObject || schemaVersion !== 0) {
+          throw new Error('Unsupported journal schema: database is not pristine');
+        }
         this.db.exec('CREATE TABLE journal_meta (version INTEGER NOT NULL) STRICT; INSERT INTO journal_meta VALUES (2); CREATE TABLE tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT;');
       } else if (tables.length !== 2) {
         // Recreating a missing records table would forget completed effects.

--- a/tests/schema-initialization.test.ts
+++ b/tests/schema-initialization.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { test } from 'node:test';
+import { Journal, SqliteStore, type Intent } from '../src/index.js';
+
+const intent: Intent = { scope: 'schema-initialization', key: 'one-effect', tool: 'append', input: { units: 1 }, recovery: 'manual' };
+
+function withFile(run: (path: string) => void): void {
+  const root = realpathSync(tmpdir());
+  const directory = realpathSync(mkdtempSync(join(root, 'journal-schema-initialization-')));
+  try { run(join(directory, 'journal.sqlite')); }
+  finally {
+    const resolved = realpathSync(directory);
+    assert.equal(resolved, directory);
+    assert.equal(dirname(resolved), root);
+    assert.ok(basename(resolved).startsWith('journal-schema-initialization-'));
+    rmSync(resolved, { recursive: true, force: true });
+  }
+}
+
+function schema(db: DatabaseSync) {
+  return db.prepare('SELECT type, name, tbl_name, rootpage, sql FROM sqlite_master ORDER BY type, name').all();
+}
+
+function rejectedOpen(path: string): void {
+  let opened: SqliteStore | undefined;
+  try {
+    assert.throws(() => { opened = new SqliteStore(path); }, /Unsupported journal schema/);
+  } finally { opened?.close(); }
+}
+
+test('losing both journal tables cannot turn a completed manual action into a fresh grant', () => {
+  withFile(path => {
+    const store = new SqliteStore(path);
+    try {
+      const journal = new Journal(store, () => 100);
+      const begun = journal.begin(intent);
+      assert.equal(begun.kind, 'acquired');
+      if (begun.kind !== 'acquired') throw new Error('Expected a lease');
+      assert.equal(journal.complete(begun.lease, { receipt: 1 }).kind, 'completed');
+    } finally { store.close(); }
+    const raw = new DatabaseSync(path);
+    try {
+      raw.exec('DROP TABLE tool_journal; DROP TABLE journal_meta');
+      const version = raw.prepare('PRAGMA schema_version').get()!.schema_version;
+      assert.ok(Number(version) > 0);
+      assert.deepEqual(schema(raw), []);
+      rejectedOpen(path);
+      assert.deepEqual(schema(raw), []);
+      assert.equal(raw.prepare('PRAGMA schema_version').get()!.schema_version, version);
+      // A rejected constructor releases its transaction and connection.
+      raw.exec('BEGIN IMMEDIATE; ROLLBACK');
+    } finally { raw.close(); }
+  });
+});
+
+test('an unrelated schema is rejected without adding journal tables or changing user rows', () => {
+  withFile(path => {
+    const raw = new DatabaseSync(path);
+    try {
+      raw.exec("CREATE TABLE app_data (id INTEGER PRIMARY KEY, value TEXT NOT NULL) STRICT; INSERT INTO app_data VALUES (1, 'keep'); CREATE VIEW app_view AS SELECT value FROM app_data;");
+      const before = schema(raw);
+      const version = raw.prepare('PRAGMA schema_version').get()!.schema_version;
+      rejectedOpen(path);
+      assert.deepEqual(schema(raw), before);
+      assert.equal(raw.prepare('SELECT value FROM app_data WHERE id=1').get()!.value, 'keep');
+      assert.equal(raw.prepare('PRAGMA schema_version').get()!.schema_version, version);
+      // Even a reset counter cannot make existing schema objects an empty DB.
+      // This raw fixture simulates an external editor; the adapter stays defensive.
+      raw.enableDefensive(false);
+      raw.exec('PRAGMA schema_version=0');
+      raw.enableDefensive(true);
+      assert.equal(raw.prepare('PRAGMA schema_version').get()!.schema_version, 0);
+      rejectedOpen(path);
+      assert.deepEqual(schema(raw), before);
+      assert.equal(raw.prepare('SELECT value FROM app_data WHERE id=1').get()!.value, 'keep');
+      assert.equal(raw.prepare('PRAGMA schema_version').get()!.schema_version, 0);
+      raw.exec('BEGIN IMMEDIATE; ROLLBACK');
+    } finally { raw.close(); }
+  });
+});
+
+for (const kind of ['new path', 'empty file'] as const) {
+  test(`${kind} can initialize and retain a completed receipt on reopen`, () => {
+    withFile(path => {
+      if (kind === 'empty file') writeFileSync(path, '', { flag: 'wx' });
+      let store = new SqliteStore(path);
+      try {
+        const journal = new Journal(store, () => 100);
+        const begun = journal.begin(intent);
+        assert.equal(begun.kind, 'acquired');
+        if (begun.kind !== 'acquired') throw new Error('Expected a lease');
+        assert.equal(begun.retry, false);
+        assert.equal(journal.complete(begun.lease, { receipt: 1 }).kind, 'completed');
+        store.close();
+        store = new SqliteStore(path);
+        assert.deepEqual(new Journal(store).begin(intent), { kind: 'replay', result: { receipt: 1 } });
+      } finally { store.close(); }
+    });
+  });
+}
+
+for (const version of [1, 2] as const) {
+  test(`existing schema v${version} keeps its receipt and identity instead of reinitializing`, () => {
+    withFile(path => {
+      const raw = new DatabaseSync(path);
+      const digest = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+      // Frozen valid wire data: this compatibility check does not use today's encoder.
+      const entry = {
+        version, id: digest([intent.scope, intent.key]), fingerprint: digest([intent.tool, intent.input, intent.recovery]),
+        recovery: 'manual', state: 'completed', epoch: 4, executor: 'existing-owner', leaseUntil: 110,
+        result: '{"receipt":1}',
+        ...(version === 2 ? { firstAcquiredAt: 100, retryForMs: null, retryStartBefore: null } : {}),
+      };
+      try {
+        raw.exec(`CREATE TABLE journal_meta (version INTEGER NOT NULL) STRICT; INSERT INTO journal_meta VALUES (${version}); CREATE TABLE tool_journal (id TEXT PRIMARY KEY, entry TEXT NOT NULL) STRICT;`);
+        raw.prepare('INSERT INTO tool_journal VALUES (?, ?)').run(entry.id, JSON.stringify(entry));
+        const store = new SqliteStore(path);
+        try {
+          assert.deepEqual(new Journal(store, () => 1_000).begin(intent), { kind: 'replay', result: { receipt: 1 } });
+          assert.equal(raw.prepare('SELECT version FROM journal_meta').get()!.version, 2);
+          assert.equal(raw.prepare('SELECT count(*) AS n FROM tool_journal').get()!.n, 1);
+          const persisted = JSON.parse(String(raw.prepare('SELECT entry FROM tool_journal WHERE id=?').get(entry.id)!.entry));
+          assert.deepEqual(persisted, {
+            ...entry, version: 2, firstAcquiredAt: version === 1 ? null : 100, retryForMs: null, retryStartBefore: null,
+          });
+        } finally { store.close(); }
+      } finally { raw.close(); }
+    });
+  });
+}


### PR DESCRIPTION
When both journal tables disappear from a previously used SQLite database, reopening it currently initializes a fresh journal and can authorize a completed logical action again. Initialization now requires an empty schema and a zero schema-version counter inside the opening transaction. Existing schema history or unrelated objects cause rejection; valid v1/v2 journals and first launches retain their behavior. The counter is a conservative recovery check, not database authentication or protection against a replacement empty file.

Package checks now reject stale compiled modules and missing source outputs. After the six CI environments pass, a read-only job saves the exact archive tested by an offline consumer, its source/build record and checksums. The public release guide explains reproduction and promotion. This prepares v0.3.1 without adding a publication credential or changing the public API.

Validation: the six new SQLite regressions fail twice on the old implementation and pass after the fix; the full local suite passes 147 core tests, nine targeted mutations, seven LangGraph tests and its demos. Negative packaging checks reject stale output and uncommitted source without emitting a candidate; the clean-source candidate passes offline installation, SQLite reopen and TypeScript consumption. Final CI results are attached to this PR.
